### PR TITLE
Simplify imports for easier local development

### DIFF
--- a/src/ontology/catalog-v001.xml
+++ b/src/ontology/catalog-v001.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-    <uri id="User Entered Import Resolution" name="https://raw.githubusercontent.com/DiseaseOntology/HumanDiseaseOntology/master/src/ontology/imports/relations.owl" uri="imports/relations.owl"/>
-    <uri id="User Entered Import Resolution" name="https://raw.githubusercontent.com/DiseaseOntology/HumanDiseaseOntology/master/src/ontology/imports/cl_import.owl" uri="imports/cl_import.owl"/>
-    <uri id="User Entered Import Resolution" name="https://raw.githubusercontent.com/DiseaseOntology/HumanDiseaseOntology/master/src/ontology/imports/hp_import.owl" uri="imports/hp_import.owl"/>
-    <uri id="User Entered Import Resolution" name="https://raw.githubusercontent.com/DiseaseOntology/HumanDiseaseOntology/master/src/ontology/imports/uberon_import.owl" uri="imports/uberon_import.owl"/>
-    <uri id="User Entered Import Resolution" name="https://raw.githubusercontent.com/DiseaseOntology/HumanDiseaseOntology/master/src/ontology/imports/ncbitaxon_import.owl" uri="imports/ncbitaxon_import.owl"/>
-    <uri id="User Entered Import Resolution" name="https://raw.githubusercontent.com/DiseaseOntology/HumanDiseaseOntology/master/src/ontology/ext.owl" uri="ext.owl"/>
     <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/doid/imports/relations.owl" uri="imports/relations.owl"/>
     <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/doid/imports/cl_import.owl" uri="imports/cl_import.owl"/>
     <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/doid/imports/hp_import.owl" uri="imports/hp_import.owl"/>
@@ -20,10 +14,10 @@
         <uri id="Automatically generated entry, Timestamp=1479837295424" name="http://purl.obolibrary.org/obo/doid/bridge/umls_bridge.owl" uri="bridge/umls_bridge.owl"/>
         <uri id="Automatically generated entry, Timestamp=1479837295424" name="http://purl.obolibrary.org/obo/doid/doid-non-classified.owl" uri="doid-non-classified.owl"/>
         <uri id="Automatically generated entry, Timestamp=1479837295424" name="http://purl.obolibrary.org/obo/doid/doid-simple.owl" uri="doid-simple.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1479837295424" name="http://purl.obolibrary.org/obo/doid/imports/imports/cl_import.owl" uri="imports/cl_import.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1479837295424" name="http://purl.obolibrary.org/obo/doid/imports/imports/go_import.owl" uri="imports/go_import.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1479837295424" name="http://purl.obolibrary.org/obo/doid/imports/imports/hp_import.owl" uri="imports/hp_import.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1479837295424" name="http://purl.obolibrary.org/obo/doid/imports/imports/ncbitaxon_import.owl" uri="imports/ncbitaxon_import.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1479837295424" name="http://purl.obolibrary.org/obo/doid/imports/cl_import.owl" uri="imports/cl_import.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1479837295424" name="http://purl.obolibrary.org/obo/doid/imports/go_import.owl" uri="imports/go_import.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1479837295424" name="http://purl.obolibrary.org/obo/doid/imports/hp_import.owl" uri="imports/hp_import.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1479837295424" name="http://purl.obolibrary.org/obo/doid/imports/ncbitaxon_import.owl" uri="imports/ncbitaxon_import.owl"/>
         <uri id="Automatically generated entry, Timestamp=1479837295424" name="http://purl.obolibrary.org/obo/doid/imports/omim_import.owl" uri="imports/omim_import.owl"/>
         <uri id="Automatically generated entry, Timestamp=1479837295424" name="http://purl.obolibrary.org/obo/doid/imports/uberon_import.owl" uri="imports/uberon_import.owl"/>
         <uri id="Automatically generated entry, Timestamp=1479837295424" name="http://purl.obolibrary.org/obo/doid/subsets/DO_FlyBase_slim.owl" uri="releases/2016-09-16/subsets/DO_FlyBase_slim.owl"/>

--- a/src/ontology/ext.owl
+++ b/src/ontology/ext.owl
@@ -5,12 +5,12 @@ Prefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)
 Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
 
 
-Ontology(<https://raw.githubusercontent.com/DiseaseOntology/HumanDiseaseOntology/master/src/ontology/ext.owl>
-Import(<https://raw.githubusercontent.com/DiseaseOntology/HumanDiseaseOntology/master/src/ontology/imports/ncbitaxon_import.owl>)
-Import(<https://raw.githubusercontent.com/DiseaseOntology/HumanDiseaseOntology/master/src/ontology/imports/uberon_import.owl>)
-Import(<https://raw.githubusercontent.com/DiseaseOntology/HumanDiseaseOntology/master/src/ontology/imports/hp_import.owl>)
-Import(<https://raw.githubusercontent.com/DiseaseOntology/HumanDiseaseOntology/master/src/ontology/imports/cl_import.owl>)
-Import(<https://raw.githubusercontent.com/DiseaseOntology/HumanDiseaseOntology/master/src/ontology/imports/relations.owl>)
+Ontology(<http://purl.obolibrary.org/obo/doid/obo/ext.owl>
+Import(<http://purl.obolibrary.org/obo/doid/imports/ncbitaxon_import.owl>)
+Import(<http://purl.obolibrary.org/obo/doid/imports/uberon_import.owl>)
+Import(<http://purl.obolibrary.org/obo/doid/imports/hp_import.owl>)
+Import(<http://purl.obolibrary.org/obo/doid/imports/cl_import.owl>)
+Import(<http://purl.obolibrary.org/obo/doid/imports/relations.owl>)
 
 SubClassOf(<http://purl.obolibrary.org/obo/DOID_0050012> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002200> <http://purl.obolibrary.org/obo/HP_0002829>))
 SubClassOf(<http://purl.obolibrary.org/obo/DOID_0050025> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/IDO_0000664> <http://purl.obolibrary.org/obo/NCBITaxon_948>))

--- a/src/ontology/imports/catalog-v001.xml
+++ b/src/ontology/imports/catalog-v001.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-    <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1467217799877" name="http://purl.obolibrary.org/obo/doid/imports/imports/cl_import.owl" uri="cl_import.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1467217799877" name="http://purl.obolibrary.org/obo/doid/imports/imports/go_import.owl" uri="go_import.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1467217799877" name="http://purl.obolibrary.org/obo/doid/imports/imports/hp_import.owl" uri="hp_import.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1467217799877" name="http://purl.obolibrary.org/obo/doid/imports/imports/ncbitaxon_import.owl" uri="ncbitaxon_import.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1467217799877" name="http://purl.obolibrary.org/obo/doid/imports/omim_import.owl" uri="omim_import.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1467217799877" name="http://purl.obolibrary.org/obo/doid/imports/uberon_import.owl" uri="uberon_import.owl"/>
-    </group>
+    <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/doid/imports/cl_import.owl" uri="cl_import.owl"/>
+    <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/doid/imports/go_import.owl" uri="go_import.owl"/>
+    <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/doid/imports/hp_import.owl" uri="hp_import.owl"/>
+    <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/doid/imports/ncbitaxon_import.owl" uri="ncbitaxon_import.owl"/>
+    <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/doid/imports/omim_import.owl" uri="omim_import.owl"/>
+    <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/doid/imports/relations.owl" uri="relations.owl"/>
+    <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/doid/imports/uberon_import.owl" uri="uberon_import.owl"/>
 </catalog>

--- a/src/ontology/imports/cl_import.owl
+++ b/src/ontology/imports/cl_import.owl
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
-<rdf:RDF xmlns="http://purl.obolibrary.org/obo/doid/imports/imports/cl_import.owl#"
-     xml:base="http://purl.obolibrary.org/obo/doid/imports/imports/cl_import.owl"
+<rdf:RDF xmlns="http://purl.obolibrary.org/obo/doid/imports/cl_import.owl#"
+     xml:base="http://purl.obolibrary.org/obo/doid/imports/cl_import.owl"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      xmlns:owl="http://www.w3.org/2002/07/owl#"
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-    <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/doid/imports/imports/cl_import.owl"/>
+    <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/doid/imports/cl_import.owl"/>
     
 
 

--- a/src/ontology/imports/hp_import.owl
+++ b/src/ontology/imports/hp_import.owl
@@ -9,13 +9,13 @@
 ]>
 
 
-<rdf:RDF xmlns="http://purl.obolibrary.org/obo/doid/imports/imports/hp_import.owl#"
-     xml:base="http://purl.obolibrary.org/obo/doid/imports/imports/hp_import.owl"
+<rdf:RDF xmlns="http://purl.obolibrary.org/obo/doid/imports/hp_import.owl#"
+     xml:base="http://purl.obolibrary.org/obo/doid/imports/hp_import.owl"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      xmlns:owl="http://www.w3.org/2002/07/owl#"
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-    <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/doid/imports/imports/hp_import.owl"/>
+    <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/doid/imports/hp_import.owl"/>
     
 
 

--- a/src/ontology/imports/ncbitaxon_import.owl
+++ b/src/ontology/imports/ncbitaxon_import.owl
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
-<rdf:RDF xmlns="http://purl.obolibrary.org/obo/doid/imports/imports/ncbitaxon_import.owl#"
-     xml:base="http://purl.obolibrary.org/obo/doid/imports/imports/ncbitaxon_import.owl"
+<rdf:RDF xmlns="http://purl.obolibrary.org/obo/doid/imports/ncbitaxon_import.owl#"
+     xml:base="http://purl.obolibrary.org/obo/doid/imports/ncbitaxon_import.owl"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      xmlns:owl="http://www.w3.org/2002/07/owl#"
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-    <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/doid/imports/imports/ncbitaxon_import.owl"/>
+    <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/doid/imports/ncbitaxon_import.owl"/>
     
 
 


### PR DESCRIPTION
The `doid-edit.owl` imports were coming directly from GitHub
instead of the local versions of `ext.owl` and `imports/`.
I changed `doid-edit.owl`, `ext.owl` and some `imports/*.owl` files,
to ensure that owl:Imports and ontology IRIs to match each other,
allowing effective use of catalog files for local development.
Then I removed the GitHub redirects from `catalog-v001.xml`.