### PR TITLE
Create OntoFox configuration for ncbitaxon_imports (take 2)

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -48,6 +48,21 @@ update-svn:
 # ----------------------------------------
 # Imports
 # ----------------------------------------
+# Get all NCBITaxon_* IDs used in doid-edit.owl and ext.owl
+imports/ncbitaxon_list.txt: doid-edit.owl ext.owl
+	grep -ho 'NCBITaxon.[0-9][0-9]*' $^ | sed 's/:/_/' | sort -u > $@
+
+# Update OntoFox import using cURL to fetch the data.
+# See http://ontofox.hegroup.org/tutorial/index.php#service
+# Also trim final comment.
+imports/%.owl: imports/%.txt
+	curl -s -F file=@$< http://ontofox.hegroup.org/service.php \
+	| sed '/^<\/rdf:RDF>/q' \
+	> $@
+
+.PHONY: ontofox_imports
+ontofox_imports: imports/ncbitaxon_import.owl
+
 all_imports: imports/omim_import.owl imports/ncit_import.owl
 
 KEEPRELS = BFO:0000050 BFO:0000051 RO:0002202 immediate_transformation_of

--- a/src/ontology/imports/ncbitaxon_import.owl
+++ b/src/ontology/imports/ncbitaxon_import.owl
@@ -1,11 +1,37 @@
 <?xml version="1.0"?>
 <rdf:RDF xmlns="http://purl.obolibrary.org/obo/doid/imports/ncbitaxon_import.owl#"
      xml:base="http://purl.obolibrary.org/obo/doid/imports/ncbitaxon_import.owl"
+     xmlns:obo="http://purl.obolibrary.org/obo/"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      xmlns:owl="http://www.w3.org/2002/07/owl#"
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
     <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/doid/imports/ncbitaxon_import.owl"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Annotation properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000412">
+        <rdfs:label xml:lang="en">imported from</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Datatypes
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
     
 
 
@@ -24,6 +50,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">root</rdfs:label>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -33,6 +60,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1003877">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Benincaseae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_3650"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -42,6 +70,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10066">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Muridae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_337687"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -51,6 +80,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10088">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mus &lt;mouse, genus&gt;</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_39107"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -60,6 +90,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10090">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mus musculus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_862507"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -69,6 +100,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10114">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rattus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_39107"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -78,6 +110,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10116">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rattus norvegicus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10114"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -87,6 +120,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10128">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Apodemus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_39107"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -96,6 +130,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10239">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Viruses</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -105,6 +140,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10240">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Poxviridae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_35237"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -114,6 +150,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10241">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Chordopoxvirinae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10240"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -123,6 +160,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10242">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Orthopoxvirus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10241"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -132,6 +170,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10243">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cowpox virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10242"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -141,6 +180,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10244">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Monkeypox virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10242"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -150,6 +190,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10245">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Vaccinia virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10242"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -159,6 +200,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10255">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Variola virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10242"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -168,6 +210,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10257">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Parapoxvirus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10241"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -177,6 +220,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10258">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Orf virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10257"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -186,6 +230,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10278">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Molluscipoxvirus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10241"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -195,6 +240,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10279">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Molluscum contagiosum virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10278"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -204,6 +250,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10292">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Herpesviridae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_548681"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -213,6 +260,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10293">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Alphaherpesvirinae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10292"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -222,6 +270,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10294">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Simplexvirus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10293"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -231,6 +280,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10298">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human herpesvirus 1</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10294"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -240,6 +290,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10310">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human herpesvirus 2</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10294"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -249,6 +300,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10319">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Varicellovirus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10293"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -258,6 +310,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10335">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human herpesvirus 3</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10319"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -267,6 +320,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10357">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Betaherpesvirinae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10292"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -276,6 +330,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10368">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human herpesvirus 6</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_431037"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -285,6 +340,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10372">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human herpesvirus 7</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_40272"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -294,6 +350,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10374">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gammaherpesvirinae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10292"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -303,6 +360,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10375">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lymphocryptovirus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10374"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -312,6 +370,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10376">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human herpesvirus 4</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10375"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -321,6 +380,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10379">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rhadinovirus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10374"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -330,6 +390,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10404">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hepadnaviridae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_35268"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -339,6 +400,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10405">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Orthohepadnavirus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10404"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -348,6 +410,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10407">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hepatitis B virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10405"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -357,6 +420,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10508">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Adenoviridae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_35237"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -366,6 +430,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10509">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mastadenovirus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10508"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -375,6 +440,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10519">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human adenovirus 7</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_565302"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -384,6 +450,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1056966">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Aedini</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_43817"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -393,6 +460,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_106178">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">canis group</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_943"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -402,6 +470,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_106179">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">phagocytophilum group</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_768"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -411,6 +480,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10780">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Parvoviridae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_29258"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -418,8 +488,9 @@
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_108098 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_108098">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human adenovirus B</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human mastadenovirus B</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10509"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -429,6 +500,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10880">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reoviridae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_35325"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -438,6 +510,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10911">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Coltivirus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_689831"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -447,6 +520,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11018">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Togaviridae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_35278"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -456,6 +530,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11019">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Alphavirus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11018"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -465,6 +540,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11020">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Barmah Forest virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11019"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -474,6 +550,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11021">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Eastern equine encephalitis virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_177873"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -483,6 +560,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11029">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ross River virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_177875"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -492,6 +570,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11036">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Venezuelan equine encephalitis virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_177872"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -499,8 +578,9 @@
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_11039 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11039">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Western equine encephalomyelitis virus</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Western equine encephalitis virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_177874"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -510,6 +590,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11040">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rubivirus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11018"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -519,6 +600,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11041">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rubella virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11040"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -528,6 +610,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11050">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Flaviviridae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_35278"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -537,6 +620,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11051">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Flavivirus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11050"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -546,6 +630,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11052">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dengue virus group</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11051"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -555,6 +640,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11053">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dengue virus 1</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_12637"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -564,6 +650,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11071">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Japanese encephalitis virus group</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11051"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -573,6 +660,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11072">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Japanese encephalitis virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11071"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -582,6 +670,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11077">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Kunjin virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11082"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -591,6 +680,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11079">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Murray Valley encephalitis virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11071"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -600,6 +690,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11080">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">St. Louis encephalitis virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11071"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -609,6 +700,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11082">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">West Nile virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11071"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -618,6 +710,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11083">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Powassan virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_29263"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -627,6 +720,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11084">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tick-borne encephalitis virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_29263"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -636,6 +730,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11086">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Louping ill virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_29263"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -645,6 +740,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11089">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Yellow fever virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_40005"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -654,6 +750,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11102">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hepacivirus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11050"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -663,6 +760,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11103">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hepatitis C virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11102"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -672,6 +770,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11118">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Coronaviridae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_76804"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -681,6 +780,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1113537">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Chlamydia/Chlamydophila group</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_809"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -690,6 +790,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_111520">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Penaeoidea</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6684"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -699,6 +800,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_111527">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pseudomallei group</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_32008"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -708,6 +810,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11157">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mononegavirales</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_35301"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -717,6 +820,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11158">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Paramyxoviridae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11157"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -726,6 +830,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11159">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Paramyxovirinae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11158"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -735,6 +840,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11161">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mumps virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_39744"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -744,6 +850,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11176">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Newcastle disease virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_260963"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -753,6 +860,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11229">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Morbillivirus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11159"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -762,6 +870,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11234">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Measles virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11229"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -771,6 +880,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11244">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pneumovirinae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11158"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -780,6 +890,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11245">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pneumovirus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11244"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -789,6 +900,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11250">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human respiratory syncytial virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11245"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -798,6 +910,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11266">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Filoviridae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11157"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -807,6 +920,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11270">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rhabdoviridae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11157"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -816,6 +930,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11286">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lyssavirus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11270"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -825,6 +940,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11292">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rabies virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11286"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -834,6 +950,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1129771">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Leptotrichiaceae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_203491"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -843,6 +960,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11308">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Orthomyxoviridae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_35301"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -852,6 +970,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11320">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Influenza A virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_197911"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -861,6 +980,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_114277">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">spotted fever group</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_780"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -870,6 +990,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_114292">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">typhus group</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_780"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -879,6 +1000,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11552">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Influenza C virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_197913"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -888,6 +1010,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11571">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bunyaviridae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_35301"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -897,6 +1020,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11572">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Orthobunyavirus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11571"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -906,6 +1030,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11577">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">La Crosse virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_35305"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -915,6 +1040,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11584">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Phlebovirus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11571"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -924,6 +1050,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11588">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rift Valley fever virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11584"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -933,6 +1060,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11592">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Nairovirus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11571"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -942,6 +1070,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11593">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Crimean-Congo hemorrhagic fever virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11592"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -951,6 +1080,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11598">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hantavirus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11571"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -960,6 +1090,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11599">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hantaan virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11598"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -969,6 +1100,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11604">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Puumala virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11598"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -978,6 +1110,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11608">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Seoul virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11598"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -987,15 +1120,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11617">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Arenaviridae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_35301"/>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/NCBITaxon_11618 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11618">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Arenavirus</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11617"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1003,8 +1128,9 @@
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_11619 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11619">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Junin virus</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_208897"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Junin mammarenavirus</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1653394"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1012,8 +1138,9 @@
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_11620 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11620">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lassa virus</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_208896"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lassa mammarenavirus</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1653394"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1021,8 +1148,9 @@
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_11623 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11623">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lymphocytic choriomeningitis virus</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_208896"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lymphocytic choriomeningitis mammarenavirus</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1653394"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1030,8 +1158,9 @@
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_11628 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11628">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Machupo virus</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_208897"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Machupo mammarenavirus</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1653394"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1041,6 +1170,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11632">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Retroviridae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_35268"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1050,6 +1180,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11646">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lentivirus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_327045"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1059,6 +1190,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11652">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Primate lentivirus group</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11646"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1068,6 +1200,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_116704">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Eubrachyura</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6752"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1077,6 +1210,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_116706">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Heterotremata</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_116704"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1086,6 +1220,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11676">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human immunodeficiency virus 1</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11652"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1095,15 +1230,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11709">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human immunodeficiency virus 2</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11652"/>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/NCBITaxon_117568 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_117568">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mitosporic Pleosporaceae</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_28556"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1113,6 +1240,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_117570">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Teleostomi</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_7776"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1122,15 +1250,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_117571">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Euteleostomi</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_117570"/>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/NCBITaxon_117573 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_117573">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mitosporic Ophiostomataceae</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_5152"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1140,6 +1260,17 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_118655">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Oropouche virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11572"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_118882 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_118882">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Brucellaceae</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_356"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1149,6 +1280,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_118968">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Coxiellaceae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_118969"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1158,6 +1290,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_118969">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Legionellales</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1236"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1167,6 +1300,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_119060">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Burkholderiaceae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_80840"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1176,6 +1310,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11908">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human T-lymphotropic virus 1</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_194440"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1185,6 +1320,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_119088">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Enoplea</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6231"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1194,6 +1330,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_119089">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Chromadorea</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6231"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1203,6 +1340,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_119093">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Trichuridae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6329"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1212,6 +1350,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_119225">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Protomacleaya</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_190765"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1221,6 +1360,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_12058">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Picornaviridae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_464095"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1230,6 +1370,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_12059">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Enterovirus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_12058"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1239,6 +1380,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_12066">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Coxsackievirus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_90010"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1248,6 +1390,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1206794">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ecdysozoa</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_33317"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1257,6 +1400,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1206795">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lophotrochozoa</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_33317"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1266,6 +1410,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_120793">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mycobacterium avium complex (MAC)</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1763"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1275,6 +1420,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_12080">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human poliovirus 1</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_138950"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1284,6 +1430,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_12083">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human poliovirus 2</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_138950"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1293,6 +1440,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_12086">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human poliovirus 3</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_138950"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1300,8 +1448,9 @@
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_12089 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_12089">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human coxsackievirus A24</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Coxsackievirus A24</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_138950"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1311,6 +1460,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_12090">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human enterovirus 70</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_138951"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1320,6 +1470,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_12091">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hepatovirus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_12058"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1329,6 +1480,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_12092">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hepatitis A virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_12091"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1338,6 +1490,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_121221">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pediculidae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_30005"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1347,6 +1500,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_121222">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pediculus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_121221"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1356,6 +1510,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_121224">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pediculus humanus corporis</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_121225"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1365,6 +1520,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_121225">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pediculus humanus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_121222"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1374,6 +1530,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_121739">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lacazia</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_34383"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1383,6 +1540,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_121752">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lacazia loboi</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_121739"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1392,6 +1550,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_121759">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Paracoccidioides brasiliensis</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_38946"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1401,6 +1560,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_122377">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Litopenaeus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6685"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1410,6 +1570,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1224">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Proteobacteria</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_2"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1419,6 +1580,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_123365">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Neoteleostei</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1489388"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1428,6 +1590,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_123366">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Eurypterygia</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_123365"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1437,6 +1600,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_123367">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ctenosquamata</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_123366"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1446,6 +1610,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_123368">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Acanthomorphata</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_123367"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1455,6 +1620,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1236">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gammaproteobacteria</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1224"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1464,6 +1630,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1239">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Firmicutes</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_2"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1473,6 +1640,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_12455">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Borna disease virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_186458"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1482,6 +1650,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_12461">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hepatitis E virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_186677"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1491,6 +1660,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_12475">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hepatitis delta virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_39759"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1500,15 +1670,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_12506">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dobrava-Belgrade virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11598"/>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/NCBITaxon_125204 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_125204">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mitosporic Dothioraceae</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_64899"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1518,6 +1680,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_12542">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Omsk hemorrhagic fever virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_29263"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1527,15 +1690,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1262365">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tabanoidea</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_43735"/>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/NCBITaxon_126331 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_126331">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mitosporic Magnaporthaceae</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_81093"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1545,6 +1700,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_12637">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dengue virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11052"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1554,6 +1710,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_127007">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rhipicephalus pumilio</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_426455"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1563,6 +1720,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1279">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Staphylococcus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_90964"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1572,6 +1730,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1280">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Staphylococcus aureus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1279"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1581,6 +1740,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1280412">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Conoidasida</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_5794"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1590,6 +1750,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1286322">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Leishmaniinae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_5654"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1599,6 +1760,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_128827">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Erysipelotrichaceae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_526525"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1608,6 +1770,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_129369">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pulicoidea</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_140693"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1617,6 +1780,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_12939">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Anemia</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_693766"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1626,6 +1790,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_129726">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pseudocowpox virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10257"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1635,6 +1800,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1300">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Streptococcaceae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_186826"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1644,6 +1810,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1301">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Streptococcus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1300"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1653,6 +1820,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_131221">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Streptophytina</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_35493"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1662,6 +1830,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1314">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Streptococcus pyogenes</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1301"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1671,6 +1840,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_131567">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cellular organisms</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1680,6 +1850,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_13203">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Phlebotomus &lt;genus&gt;</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_7198"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1689,6 +1860,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1329799">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Archelosauria</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_32561"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1698,6 +1870,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_133423">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Batillus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_63672"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1707,6 +1880,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_13373">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Burkholderia mallei</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_111527"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1716,6 +1890,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1338369">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dipnotetrapodomorpha</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_8287"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1725,6 +1900,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_133894">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Penaeus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6685"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1734,6 +1910,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_133898">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fenneropenaeus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6685"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1743,6 +1920,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_134362">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Capnodiales</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_451867"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1752,6 +1930,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_134742">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sigmodon alstoni</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_42414"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1761,6 +1940,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_135625">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pasteurellales</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1236"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1770,15 +1950,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_136">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Spirochaetales</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_203692"/>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/NCBITaxon_137 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_137">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Spirochaetaceae</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_136"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1788,6 +1960,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_137207">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Oligoryzomys longicaudatus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_29120"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1796,7 +1969,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_138">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Borrelia</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_137"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1643685"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1806,6 +1980,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1385">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bacillales</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_91061"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1815,6 +1990,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1386">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bacillus &lt;bacterium&gt;</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_186817"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1822,8 +1998,9 @@
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_138948 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_138948">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human enterovirus A</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Enterovirus A</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_12059"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1831,8 +2008,9 @@
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_138949 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_138949">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human enterovirus B</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Enterovirus B</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_12059"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1840,8 +2018,9 @@
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_138950 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_138950">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human enterovirus C</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Enterovirus C</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_12059"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1849,8 +2028,9 @@
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_138951 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_138951">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human enterovirus D</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Enterovirus D</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_12059"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1860,6 +2040,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_139">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Borrelia burgdorferi</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_64895"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1869,6 +2050,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1392">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bacillus anthracis</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_86661"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1878,6 +2060,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_140564">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ornithodoros parkeri</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6937"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1887,6 +2070,17 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_140693">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pulicomorpha</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_7509"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_1437010 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1437010">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Boreoeutheria</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_9347"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1896,6 +2090,17 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1437183">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mesangiospermae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_3398"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_1437197 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1437197">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Petrosaviidae</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_4447"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1905,6 +2110,37 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1437201">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pentapetalae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_91827"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_1457286 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1457286">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dorylaimia</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_119088"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_147368 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_147368">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pooideae</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_359160"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_147387 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_147387">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Poeae</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1648037"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1914,6 +2150,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_147537">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Saccharomycotina</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_716545"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1923,6 +2160,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_147538">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pezizomycotina</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_716545"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1932,6 +2170,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_147541">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dothideomycetes</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_715962"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1941,6 +2180,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_147545">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Eurotiomycetes</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_716546"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1950,6 +2190,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_147550">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sordariomycetes</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_715989"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1959,6 +2200,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_147553">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pneumocystidomycetes</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_451866"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1968,6 +2210,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1485">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Clostridium</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_31979"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1977,6 +2220,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1489341">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Osteoglossocephalai</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_32443"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1986,6 +2230,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1489388">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Euteleosteomorpha</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_186625"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -1995,6 +2240,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1489838">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Paracanthomorphacea</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_123368"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2004,6 +2250,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1489841">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Zeiogadaria</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1489838"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2013,6 +2260,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1489843">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gadariae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1489841"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2022,6 +2270,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1489845">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gadoidei</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_8043"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2031,6 +2280,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1491">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Clostridium botulinum</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1485"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2040,6 +2290,17 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1502">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Clostridium perfringens</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1485"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_1511862 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1511862">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Carnivore amdoparvovirus 1</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_310911"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2049,6 +2310,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1513">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Clostridium tetani</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1485"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2058,6 +2320,17 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_151340">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Papillomaviridae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_35237"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_1521262 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1521262">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Polypodiidae &lt;ferns&gt;</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_241806"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2067,6 +2340,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_153136">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Deltaretrovirus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_327045"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2076,6 +2350,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1549675">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Galloanserae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_8825"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2085,6 +2360,17 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_155616">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tremellomycetes</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_5302"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_1570301 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1570301">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Aureobasidiaceae</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_5014"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2094,6 +2380,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_157540">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Zygodontomys</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_40141"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2103,6 +2390,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_157541">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Zygodontomys brevicauda</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_157540"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2112,6 +2400,27 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_157914">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ziziphus mauritiana</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_72171"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_15956 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_15956">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Phleum</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_640628"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_15957 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_15957">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Phleum pratense</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_15956"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2121,6 +2430,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_162997">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Culex annulirostris</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_53527"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2130,6 +2440,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_163158">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Xenopsylla</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_476427"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2139,6 +2450,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_163159">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Xenopsylla cheopis</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_163158"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2148,6 +2460,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1637">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Listeria</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_186820"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2157,6 +2470,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1639">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Listeria monocytogenes</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1637"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2166,6 +2480,27 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1639119">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Plasmodiidae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_5819"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_1643685 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1643685">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Borreliaceae</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_136"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_1643688 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1643688">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Leptospirales</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_203692"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2175,6 +2510,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1647">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Erysipelothrix</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_128827"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2184,6 +2520,47 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1648">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Erysipelothrix rhusiopathiae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1647"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_1648037 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1648037">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Poodae</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_147368"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_1649845 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1649845">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Yersinia pseudotuberculosis complex</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_629"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_1652081 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1652081">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Poeae Chloroplast Group 2 (Poeae type)</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_147387"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_1653394 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1653394">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mammarenavirus</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11617"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2193,6 +2570,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1654">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Actinomyces</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_2049"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2202,6 +2580,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1655">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Actinomyces naeslundii</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1654"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2211,6 +2590,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1656">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Actinomyces viscosus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1654"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2220,6 +2600,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1659">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Actinomyces israelii</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1654"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2229,6 +2610,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1660">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Actinomyces odontolyticus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1654"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2238,6 +2620,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_169440">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Coelopidae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_43750"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2247,6 +2630,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_169449">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Coelopinae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_169440"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2256,6 +2640,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_169455">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Coelopellini</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_169449"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2265,6 +2650,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_169495">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_169455"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2273,7 +2659,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_170">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Leptospiraceae</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_136"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1643688"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2283,6 +2670,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_171">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Leptospira</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_170"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2292,6 +2680,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_171637">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Maloideae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_3745"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2301,6 +2690,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_172148">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Alkhumra hemorrhagic fever virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_33743"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2310,6 +2700,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1728959">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Aurantioideae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_23513"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2319,6 +2710,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_173087">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human papillomavirus types</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_333774"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2328,6 +2720,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1743">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Propionibacterium</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_31957"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2337,6 +2730,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1750">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Propionibacterium propionicum</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1743"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2346,6 +2740,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1760">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Actinobacteria &lt;class&gt;</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_201174"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2355,6 +2750,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1762">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mycobacteriaceae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_85007"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2364,6 +2760,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1763">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mycobacterium</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1762"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2373,6 +2770,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1769">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mycobacterium leprae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1763"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2382,6 +2780,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1773">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mycobacterium tuberculosis</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_77643"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2391,6 +2790,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_177872">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">VEEV complex</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11019"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2400,6 +2800,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_177873">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EEEV complex</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11019"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2409,6 +2810,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_177874">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">WEEV complex</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11019"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2418,6 +2820,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_177875">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SFV complex</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11019"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2427,6 +2830,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_178830">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bornaviridae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11157"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2436,6 +2840,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1809">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mycobacterium ulcerans</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1763"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2445,6 +2850,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_181088">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Haemaphysalis flava</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_34622"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2454,6 +2860,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1817">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Nocardia</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_85025"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2463,6 +2870,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1824">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Nocardia asteroides</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1817"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2472,6 +2880,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_186458">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bornavirus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_178830"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2481,6 +2890,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_186536">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ebolavirus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11266"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2490,6 +2900,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_186537">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Marburgvirus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11266"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2499,6 +2910,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_186538">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Zaire ebolavirus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_186536"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2508,6 +2920,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_186540">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sudan ebolavirus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_186536"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2517,6 +2930,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_186623">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Actinopteri</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_7898"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2526,6 +2940,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_186625">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Clupeocephala</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1489341"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2535,6 +2950,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_186626">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Otophysa</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_32519"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2544,6 +2960,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_186627">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cypriniphysae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_186626"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2553,6 +2970,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_186634">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Otomorpha</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_186625"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2562,6 +2980,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_186677">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hepevirus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_291484"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2571,6 +2990,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_186801">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Clostridia</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1239"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2580,6 +3000,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_186802">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Clostridiales</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_186801"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2589,6 +3010,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_186817">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bacillaceae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1385"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2598,6 +3020,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_186820">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Listeriaceae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1385"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2607,6 +3030,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_186826">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lactobacillales</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_91061"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2616,6 +3040,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_190765">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ochlerotatus &lt;genus&gt;</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1056966"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2625,6 +3050,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_194">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Campylobacter</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_72294"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2634,6 +3060,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_194440">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Primate T-lymphotropic virus 1</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_153136"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2643,6 +3070,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_197">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Campylobacter jejuni</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_194"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2652,6 +3080,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_197562">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pancrustacea</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_197563"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2661,6 +3090,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_197563">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mandibulata</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6656"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2670,6 +3100,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_197911">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Influenzavirus A</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11308"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2679,6 +3110,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_197912">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Influenzavirus B</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11308"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2688,6 +3120,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_197913">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Influenzavirus C</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11308"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2695,8 +3128,9 @@
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_2 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bacteria</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bacteria &lt;prokaryote&gt;</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_131567"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2706,6 +3140,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_201174">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Actinobacteria &lt;phylum&gt;</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_2"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2715,6 +3150,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_203397">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rotaliacea</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_29185"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2724,6 +3160,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_203490">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fusobacteriia</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_32066"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2733,6 +3170,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_203491">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fusobacteriales</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_203490"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2742,6 +3180,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_203691">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Spirochaetes</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_2"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2751,6 +3190,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_203692">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Spirochaetia</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_203691"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2759,7 +3199,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2037">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Actinomycetales</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_85003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1760"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2769,6 +3210,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_204428">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Chlamydiae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_51290"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2778,6 +3220,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_204429">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Chlamydiia</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_204428"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2786,7 +3229,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2049">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Actinomycetaceae</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_85005"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_2037"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2796,6 +3240,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_206160">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sandfly fever Naples virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11584"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2805,24 +3250,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_206351">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Neisseriales</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_28216"/>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/NCBITaxon_208896 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_208896">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Old world arenaviruses</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11618"/>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/NCBITaxon_208897 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_208897">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">New world arenaviruses</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11618"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2832,6 +3260,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_213849">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Campylobacterales</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_29547"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2841,6 +3270,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_216275">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Vetigastropoda</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6448"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2850,6 +3280,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_216285">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Trochoidea &lt;superfamily&gt;</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_216275"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2859,6 +3290,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_222543">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hypocreomycetidae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_147550"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2868,6 +3300,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_222544">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sordariomycetidae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_147550"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2877,6 +3310,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_226665">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rickettsia heilongjiangensis</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_114277"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2886,6 +3320,27 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_227859">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SARS coronavirus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_694009"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_234 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_234">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Brucella</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_118882"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_235 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_235">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Brucella abortus</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_234"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2895,6 +3350,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_23513">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rutaceae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_41937"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2904,6 +3360,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_241806">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Moniliformopses</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_78536"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2913,6 +3370,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_260963">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Avulavirus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11159"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2922,6 +3380,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_262">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Francisella</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_34064"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2931,6 +3390,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_263">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Francisella tularensis</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_262"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2940,6 +3400,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_266068">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rickettsia sibirica subgroup</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_114277"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2949,6 +3410,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2706">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Citrus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1728959"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2958,15 +3420,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2711">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Citrus sinensis</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_2706"/>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/NCBITaxon_27316 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_27316">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Galactomyces</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_34353"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2974,8 +3428,9 @@
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_27317 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_27317">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Galactomyces geotrichum</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_27316"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Geotrichum candidum [NCBITaxon:27317]</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_43987"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2985,6 +3440,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_27458">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Chrysops</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_59848"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -2994,6 +3450,17 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2759">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Eukaryota</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_131567"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_27592 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_27592">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bovinae</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_9895"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3003,6 +3470,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_279271">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Leptotrombidium</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_92251"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3012,6 +3480,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_27973">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Encephalitozoon hellem</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6033"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3021,6 +3490,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_28211">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Alphaproteobacteria</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1224"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3030,6 +3500,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_28216">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Betaproteobacteria</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1224"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3039,6 +3510,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_28292">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sandfly fever Sicilian virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_327794"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3047,7 +3519,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_28314">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Aleutian mink disease virus</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_310911"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1511862"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3057,6 +3530,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_28450">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Burkholderia pseudomallei</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_111527"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3066,6 +3540,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_28556">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pleosporaceae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_715340"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3075,6 +3550,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_28568">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Trichocomaceae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_5042"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3084,6 +3560,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_29031">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Phlebotomus papatasi</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_44556"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3093,6 +3570,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_29105">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Calomys</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_40141"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3102,6 +3580,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_29120">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Oligoryzomys</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_40141"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3111,6 +3590,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_29122">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Oryzomys</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_40141"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3120,6 +3600,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_291484">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hepeviridae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_35278"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3129,6 +3610,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_29178">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Foraminifera</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_543769"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3138,6 +3620,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_29185">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rotaliida</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_29178"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3147,6 +3630,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_29189">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ammonia</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_69034"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3156,6 +3640,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_29258">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ssDNA viruses</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10239"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3165,6 +3650,27 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_29263">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tick-borne encephalitis virus group</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11051"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_29459 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_29459">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Brucella melitensis</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_234"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_29461 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_29461">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Brucella suis</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_234"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3174,6 +3680,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_29547">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Epsilonproteobacteria</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_68525"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3183,6 +3690,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_297308">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ixodoidea</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6935"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3191,7 +3699,18 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_29907">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sporothrix</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_117573"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_5152"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_299071 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_299071">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ajellomycetaceae</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_33183"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3201,6 +3720,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_29908">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sporothrix schenckii</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_29907"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3210,6 +3730,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_29930">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ixodes pacificus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6944"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3219,6 +3740,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_299467">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Leptotrombidium deliense</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_279271"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3228,6 +3750,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_29960">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fenneropenaeus indicus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_133898"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3237,6 +3760,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_30005">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Anoplura</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_85819"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3246,6 +3770,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_30639">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mastomys</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_39107"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3255,6 +3780,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_30727">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cyprinoidea</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_7952"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3262,8 +3788,19 @@
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_310911 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_310911">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Amdovirus</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Amdoparvovirus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_40119"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_314145 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_314145">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Laurasiatheria</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1437010"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3272,7 +3809,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_314146">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Euarchontoglires</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_9347"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1437010"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3282,6 +3820,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_314147">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Glires</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_314146"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3289,8 +3828,9 @@
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_31704 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_31704">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human coxsackievirus A16</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Coxsackievirus A16</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_138948"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3300,6 +3840,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_3193">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Embryophyta</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_131221"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3309,6 +3850,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_31957">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Propionibacteriaceae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_85009"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3318,6 +3860,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_31979">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Clostridiaceae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_186802"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3327,6 +3870,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_32008">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Burkholderia</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_119060"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3336,6 +3880,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_32066">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fusobacteria</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_2"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3345,6 +3890,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_32443">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Teleostei</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_41665"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3354,6 +3900,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_32519">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ostariophysi</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_186634"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3363,7 +3910,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_32523">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tetrapoda</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1338369"/>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_8287"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3373,6 +3920,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_32524">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Amniota</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_32523"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3382,6 +3930,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_32525">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Theria &lt;Mammalia&gt;</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_40674"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3391,6 +3940,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_325284">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Paliureae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_3608"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3400,6 +3950,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_32561">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sauria</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_8457"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3409,6 +3960,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_327045">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Orthoretrovirinae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11632"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3418,15 +3970,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_327794">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unclassified Phlebovirus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11584"/>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/NCBITaxon_3290 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_3290">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Polypodiopsida</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_241806"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3436,6 +3980,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_329110">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Coquillettidia</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_53550"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3445,6 +3990,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_33090">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Viridiplantae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_2759"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3454,6 +4000,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_33154">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Opisthokonta</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_2759"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3463,6 +4010,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_33183">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Onygenales</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_451871"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3472,6 +4020,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_33208">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Metazoa</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_33154"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3481,15 +4030,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_33213">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bilateria</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6072"/>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/NCBITaxon_33218 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_33218">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Enoplia</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_119088"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3499,6 +4040,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_33256">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ascaridoidea</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6249"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3508,6 +4050,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_33317">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Protostomia</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_33213"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3517,6 +4060,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_33340">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Neoptera</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_7496"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3526,6 +4070,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_33342">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Paraneoptera</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_33340"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3535,6 +4080,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_333774">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unclassified Papillomaviridae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_151340"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3544,6 +4090,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_33392">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Endopterygota</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_33340"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3553,6 +4100,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_33511">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Deuterostomia</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_33213"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3562,6 +4110,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_33553">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sciurognathi</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_9989"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3571,6 +4120,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_33630">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Alveolata</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_2759"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3580,6 +4130,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_33682">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Euglenozoa</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_2759"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3589,6 +4140,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_33743">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Kyasanur forest disease virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_29263"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3598,6 +4150,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_337677">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cricetidae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_337687"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3607,6 +4160,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_337687">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Muroidea</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_33553"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3616,6 +4170,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_337963">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Neotominae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_337677"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3625,6 +4180,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_3398">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Magnoliophyta</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_58024"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3634,6 +4190,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_33988">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rickettsieae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_775"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3643,6 +4200,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_33993">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Neorickettsia</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_942"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3652,6 +4210,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_34064">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Francisellaceae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_72273"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3661,6 +4220,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_34104">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Streptobacillus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1129771"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3670,6 +4230,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_34105">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Streptobacillus moniliformis</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_34104"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3679,6 +4240,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_34353">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dipodascaceae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_4892"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3688,6 +4250,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_34383">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mitosporic Onygenales</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_33183"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3697,15 +4260,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_34384">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Arthrodermataceae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_33183"/>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/NCBITaxon_34385 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_34385">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mitosporic Arthrodermataceae</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_34384"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3714,16 +4269,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_34390">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Epidermophyton</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_34385"/>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/NCBITaxon_34392 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_34392">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Microsporum</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_34384"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3733,15 +4280,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_34395">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Chaetothyriales</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_451870"/>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/NCBITaxon_34476 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_34476">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mitosporic Tremellales</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_5234"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3751,6 +4290,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_34607">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Amblyomma cajennense</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6942"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3760,6 +4300,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_34608">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Amblyomma hebraeum</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6942"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3769,6 +4310,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_34609">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Amblyomma maculatum</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6942"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3778,6 +4320,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_34610">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Amblyomma variegatum</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6942"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3787,6 +4330,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_34613">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ixodes ricinus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6944"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3796,6 +4340,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_34619">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dermacentor</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_426437"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3805,6 +4350,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_34620">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dermacentor andersoni</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_34619"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3814,6 +4360,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_34621">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dermacentor variabilis</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_34619"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3823,6 +4370,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_34622">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Haemaphysalis</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_426439"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3832,6 +4380,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_34625">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hyalomma</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_426438"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3841,6 +4390,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_34630">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rhipicephalus &lt;genus&gt;</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_426437"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3850,15 +4400,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_34632">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rhipicephalus sanguineus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_578835"/>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/NCBITaxon_352061 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_352061">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ornithodorinae</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6936"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3868,6 +4410,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_35237">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dsDNA viruses, no RNA stage</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10239"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3877,6 +4420,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_35268">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Retro-transcribing viruses</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10239"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3886,6 +4430,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_35278">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ssRNA positive-strand viruses, no DNA stage</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_439488"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3895,6 +4440,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_35301">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ssRNA negative-strand viruses</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_439488"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3904,6 +4450,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_35305">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">California encephalitis virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11572"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3913,6 +4460,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_35325">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dsRNA viruses</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10239"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3922,6 +4470,17 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_35493">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Streptophyta</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_33090"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_35500 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_35500">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pecora</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_9845"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3931,6 +4490,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_356">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rhizobiales</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_28211"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3940,6 +4500,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_35788">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rickettsia africae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_114277"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3949,6 +4510,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_35789">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rickettsia helvetica</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_114277"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3958,6 +4520,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_35790">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rickettsia japonica</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_114277"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3967,6 +4530,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_35792">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rickettsia parkeri</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_114277"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3976,6 +4540,17 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_35793">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rickettsia sibirica</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_266068"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_359160 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_359160">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BOP clade</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_4479"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3985,6 +4560,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_36051">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mitosporic Chaetothyriales</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_34395"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -3994,6 +4570,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_3608">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rhamnaceae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_3744"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4003,6 +4580,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_36086">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Trichuris</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_119093"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4012,6 +4590,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_36087">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Trichuris trichiura</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_36086"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4021,6 +4600,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_36330">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Plasmodium ovale</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_418103"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4030,6 +4610,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_3650">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cucurbitaceae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_71239"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4039,6 +4620,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_3655">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cucumis</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1003877"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4048,6 +4630,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_3656">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cucumis melo</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_3655"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4057,6 +4640,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_36596">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Prunus armeniaca</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_3754"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4066,6 +4650,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_36734">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Unikaryonidae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6032"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4075,6 +4660,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_36826">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Clostridium botulinum A</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1491"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4084,6 +4670,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_36827">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Clostridium botulinum B</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1491"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4093,6 +4680,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_36830">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Clostridium botulinum E</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1491"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4102,6 +4690,17 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_36831">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Clostridium botulinum F</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1491"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_36855 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_36855">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Brucella canis</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_234"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4111,6 +4710,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_37020">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Oryzomys palustris</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_29122"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4120,6 +4720,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_37162">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mycobacterium avium complex</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_120793"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4129,6 +4730,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_37296">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human herpesvirus 8</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10379"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4138,6 +4740,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_3744">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rosales</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_91835"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4147,6 +4750,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_3745">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rosaceae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_3744"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4156,6 +4760,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_3749">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Malus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_721813"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4165,6 +4770,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_3750">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Malus domestica</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_3749"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4174,6 +4780,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_3754">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Prunus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_721805"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4183,6 +4790,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_3758">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Prunus domestica</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_3754"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4192,6 +4800,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_3760">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Prunus persica</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_3754"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4201,6 +4810,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_37705">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sin Nombre virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11598"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4210,6 +4820,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_37727">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Talaromyces marneffei</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_5094"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4219,6 +4830,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_37816">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rickettsia honei</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_114277"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4228,6 +4840,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_37962">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bayou virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11598"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4237,6 +4850,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_37987">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pneumocystidales</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_147553"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4246,6 +4860,17 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_38323">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bartonella henselae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_773"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_38820 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_38820">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Poales</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_4734"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4255,6 +4880,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_38946">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Paracoccidioides</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_34383"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4264,6 +4890,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_39030">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Apodemus agrarius</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10128"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4271,8 +4898,9 @@
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_39054 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_39054">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human enterovirus 71</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Enterovirus A71</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_138948"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4282,6 +4910,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_39087">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Arvicolinae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_337677"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4291,6 +4920,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_39107">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Murinae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10066"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4300,6 +4930,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_39744">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rubulavirus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11159"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4309,6 +4940,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_39759">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Deltavirus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10239"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4318,6 +4950,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_39824">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Klebsiella granulomatis</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_570"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4327,6 +4960,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_40005">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Yellow fever virus group</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11051"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4336,6 +4970,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_400053">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sylvaemus group</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10128"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4345,6 +4980,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_40119">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Parvovirinae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10780"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4354,6 +4990,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_40141">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sigmodontinae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_337677"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4363,6 +5000,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_40272">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Roseolovirus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10357"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4372,6 +5010,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_40411">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Chrysosporium</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_34383"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4381,6 +5020,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_40674">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mammalia</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_32524"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4390,6 +5030,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_4069">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Solanales</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_91888"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4399,6 +5040,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_4070">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Solanaceae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_4069"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4408,6 +5050,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_4081">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Solanum lycopersicum</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_49274"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4417,6 +5060,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_4107">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Solanum</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_424574"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4426,6 +5070,17 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_41283">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Chrysosporium parvum</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_40411"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_415703 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_415703">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tremellales incertae sedis</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_5234"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4435,6 +5090,17 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_41665">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Neopterygii</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_186623"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_41687 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_41687">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Scedosporium</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_5593"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4444,6 +5110,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_41705">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Protacanthopterygii</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1489388"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4453,6 +5120,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_418103">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Plasmodium (Plasmodium)</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_5820"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4462,6 +5130,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_418107">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Plasmodium (Laverania)</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_5820"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4471,6 +5140,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_41819">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ceratopogonidae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_41828"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4480,6 +5150,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_41820">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Culicoides &lt;genus&gt;</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_58262"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4489,6 +5160,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_41827">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Culicoidea</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_43786"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4498,6 +5170,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_41828">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Chironomoidea</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_43786"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4507,6 +5180,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_41831">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Psychodoidea</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_43787"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4516,6 +5190,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_41937">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sapindales</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_91836"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4525,6 +5200,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_42068">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pneumocystis jirovecii</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_4753"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4534,6 +5210,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_42229">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Prunus avium</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_3754"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4543,6 +5220,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_422676">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Aconoidasida</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_5794"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4552,6 +5230,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_423054">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Eimeriorina</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_75739"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4561,6 +5240,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_42407">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Neotoma</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_337963"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4570,6 +5250,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_42408">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Neotoma albigula</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_42407"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4579,6 +5260,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_42414">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sigmodon</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_40141"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4588,6 +5270,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_42415">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sigmodon hispidus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_42414"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4597,6 +5280,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_424551">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Solanoideae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_4070"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4606,6 +5290,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_424574">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Solaneae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_424551"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4615,6 +5300,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_426437">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rhipicephalinae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6939"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4624,6 +5310,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_426438">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hyalomminae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6939"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4633,6 +5320,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_426439">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Haemaphysalinae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6939"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4642,6 +5330,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_426441">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Amblyomminae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6939"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4651,6 +5340,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_426442">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ixodinae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6939"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4660,6 +5350,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_426455">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rhipicephalus &lt;subgenus&gt;</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_34630"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4669,6 +5360,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_42862">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rickettsia felis</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_114277"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4678,6 +5370,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_431037">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unclassified Roseolovirus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_40272"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4687,6 +5380,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_43219">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Herpotrichiellaceae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_34395"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4696,6 +5390,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_436486">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dinosauria</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_8492"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4705,6 +5400,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_436489">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Saurischia</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_436486"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4714,6 +5410,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_436491">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Theropoda</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_436489"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4723,6 +5420,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_436492">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Coelurosauria</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_436491"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4732,6 +5430,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_43733">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Muscomorpha</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_7203"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4741,6 +5440,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_43735">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tabanomorpha</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_7203"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4750,6 +5450,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_43738">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Schizophora</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_480117"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4759,6 +5460,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_43741">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Acalyptratae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_43738"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4768,6 +5470,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_43750">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sciomyzoidea</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_43741"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4775,8 +5478,9 @@
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_43786 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_43786">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Culicimorpha</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Culicomorpha</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_7148"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4786,6 +5490,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_43787">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Psychodomorpha</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_7148"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4795,6 +5500,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_43801">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ceratopogoninae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_41819"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4804,6 +5510,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_43816">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Anophelinae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_7157"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4813,6 +5520,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_43817">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Culicinae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_7157"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4822,6 +5530,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_43920">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Chrysopsinae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_7205"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4831,6 +5540,17 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_439488">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ssRNA viruses</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10239"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_43987 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_43987">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Geotrichum</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_34353"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4840,6 +5560,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_44281">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pneumocystidaceae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_37987"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4849,6 +5570,17 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_444">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Legionellaceae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_118969"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_4447 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_4447">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Liliopsida</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1437183"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4858,6 +5590,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_445">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Legionella</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_444"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4867,6 +5600,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_44534">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cellia &lt;subgenus&gt;</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_7164"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4876,6 +5610,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_44537">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pyretophorus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_44534"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4885,6 +5620,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_44542">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gambiae species complex</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_44537"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4894,6 +5630,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_44556">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Phlebotomus &lt;subgenus&gt;</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_13203"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4903,6 +5640,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_446">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Legionella pneumophila</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_445"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4912,6 +5650,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_447134">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Myodes</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_39087"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4921,6 +5660,17 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_447135">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Myodes glareolus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_447134"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_4479 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_4479">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Poaceae</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_38820"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4930,6 +5680,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_451864">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dikarya</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_4751"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4939,6 +5690,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_451866">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Taphrinomycotina</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_4890"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4948,6 +5700,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_451867">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dothideomycetidae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_147541"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4957,6 +5710,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_451868">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pleosporomycetidae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_147541"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4966,6 +5720,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_451870">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Chaetothyriomycetidae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_147545"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4975,6 +5730,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_451871">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Eurotiomycetidae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_147545"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4982,8 +5738,9 @@
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_45219 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_45219">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Guanarito virus</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_208897"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Guanarito mammarenavirus</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1653394"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -4991,17 +5748,9 @@
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_452563 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_452563">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Davidiellaceae</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cladosporiaceae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_134362"/>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/NCBITaxon_452564 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_452564">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mitosporic Davidiellaceae</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_452563"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5011,6 +5760,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_45659">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human adenovirus 3</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_565302"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5018,8 +5768,9 @@
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_45709 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_45709">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sabia virus</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_208897"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sabia mammarenavirus</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1653394"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5029,6 +5780,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_464095">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Picornavirales</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_35278"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5038,6 +5790,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_46607">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Andes virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11598"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5047,6 +5800,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_46839">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Colorado tick fever virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10911"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5054,8 +5808,19 @@
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_46919 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_46919">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Whitewater Arroyo virus</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_208897"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Whitewater Arroyo mammarenavirus</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1653394"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_4734 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_4734">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">commelinids</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1437197"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5065,6 +5830,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_4751">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fungi</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_33154"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5074,6 +5840,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_4753">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pneumocystis</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_44281"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5083,6 +5850,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_476427">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Xenopsyllinae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_7511"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5092,6 +5860,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_480117">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cyclorrhapha</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_480118"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5101,6 +5870,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_480118">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Eremoneura</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_43733"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5110,6 +5880,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_481">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Neisseriaceae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_206351"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5119,6 +5890,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_482">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Neisseria</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_481"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5128,6 +5900,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_485">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Neisseria gonorrhoeae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_482"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5137,6 +5910,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_4890">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ascomycota</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_451864"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5146,6 +5920,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_4891">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Saccharomycetes</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_147537"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5155,6 +5930,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_4892">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Saccharomycetales</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_4891"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5164,6 +5940,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_49202">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dermacentor marginatus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_34619"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5173,6 +5950,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_49274">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lycopersicon</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_4107"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5180,8 +5958,9 @@
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_499556 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_499556">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Chapare virus</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_208897"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Chapare mammarenavirus</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1653394"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5191,6 +5970,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5014">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dothideales</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_451867"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5200,6 +5980,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5042">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Eurotiales</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_451871"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5209,6 +5990,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_504568">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Salmoninae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_8015"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5218,6 +6000,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_50557">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Insecta</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6960"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5227,6 +6010,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_506">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Alcaligenaceae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_80840"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5236,6 +6020,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5094">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Talaromyces</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_28568"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5245,6 +6030,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_51290">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Chlamydiae/Verrucomicrobia group</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_2"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5254,6 +6040,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_51291">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Chlamydiales</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_204429"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5263,6 +6050,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5151">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ophiostomatales</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_222544"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5272,6 +6060,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5152">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ophiostomataceae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_5151"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5281,6 +6070,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_517">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bordetella</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_506"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5290,6 +6080,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_519">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bordetella parapertussis</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_517"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5299,6 +6090,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_520">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bordetella pertussis</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_517"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5308,6 +6100,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5204">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Basidiomycota</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_451864"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5317,6 +6110,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_523089">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Haemaphysalis concinna</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_34622"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5326,6 +6120,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_523103">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Trichophyton mentagrophytes</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_5550"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5335,6 +6130,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5234">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tremellales</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_155616"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5342,8 +6138,9 @@
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_526524 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_526524">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Erysipelotrichi</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Erysipelotrichia</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1239"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5353,6 +6150,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_526525">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Erysipelotrichales</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_526524"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5362,6 +6160,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_52769">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Actinomyces gerencseriae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1654"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5371,6 +6170,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_52773">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Actinomyces meyeri</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1654"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5380,6 +6180,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5302">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Agaricomycotina</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_5204"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5389,6 +6190,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_53527">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Culex &lt;subgenus&gt;</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_7174"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5398,6 +6200,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_53549">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sabethini</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_43817"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5407,6 +6210,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_53550">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Culicini</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_43817"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5416,6 +6220,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_53551">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sabethes</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_53549"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5425,6 +6230,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_54292">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Apodemus flavicollis</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_400053"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5434,6 +6240,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_543">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Enterobacteriaceae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_91347"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5443,6 +6250,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_543769">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rhizaria</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_2759"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5452,6 +6260,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_548681">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Herpesvirales</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_35237"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5460,7 +6269,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5498">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cladosporium</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_452564"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_452563"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5470,6 +6280,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5500">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Coccidioides</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_34383"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5479,6 +6290,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5501">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Coccidioides immitis</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_5500"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5487,7 +6299,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5550">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Trichophyton</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_34385"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_34384"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5496,7 +6309,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5552">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Trichosporon &lt;Trichosporonales&gt;</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_34476"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_415703"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5505,7 +6319,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5579">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Aureobasidium</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_125204"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1570301"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5513,8 +6328,9 @@
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_5583 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5583">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Exophiala</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_82104"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Exophiala &lt;Herpotrichiellaceae&gt;</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_43219"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5523,7 +6339,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5587">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rhinocladiella</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_82104"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_43219"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5533,6 +6350,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5592">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Microascales</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_222543"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5542,15 +6360,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5593">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Microascaceae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_5592"/>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/NCBITaxon_5596 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5596">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pseudallescheria</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_5593"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5558,8 +6368,9 @@
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_5597 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5597">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pseudallescheria boydii</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_5596"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Scedosporium boydii</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_41687"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5568,7 +6379,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5598">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Alternaria</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_117568"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_28556"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5576,8 +6388,9 @@
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_5600 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5600">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Phialophora</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_126331"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Phialophora &lt;Chaetothyriales&gt;</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_43219"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5587,6 +6400,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_56210">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Calomys callosus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_29105"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5596,6 +6410,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_56211">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Calomys laucha</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_29105"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5605,6 +6420,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_56212">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Calomys musculinus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_29105"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5614,6 +6430,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_56426">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bartonella clarridgeiae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_773"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5623,6 +6440,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5653">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Kinetoplastida</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_33682"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5632,6 +6450,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_565302">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human adenovirus B1</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_108098"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5641,6 +6460,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5654">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Trypanosomatidae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_5653"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5650,6 +6470,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5658">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Leishmania &lt;genus&gt;</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1286322"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5657,8 +6478,9 @@
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_565995 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_565995">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bundibugyo ebolavirus</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bundibugyo virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_186536"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5668,6 +6490,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_570">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Klebsiella</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_543"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5677,6 +6500,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_578835">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rhipicephalus sanguineus group</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_426455"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5686,6 +6510,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5794">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Apicomplexa</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_33630"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5695,6 +6520,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5796">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Coccidia</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1280412"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5704,6 +6530,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_58023">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tracheophyta</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_3193"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5713,6 +6540,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_58024">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Spermatophyta</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_78536"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5722,6 +6550,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5809">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sarcocystidae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_423054"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5731,6 +6560,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5810">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Toxoplasma</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_5809"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5740,6 +6570,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5811">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Toxoplasma gondii</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_5810"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5749,6 +6580,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5819">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Haemosporida</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_422676"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5758,6 +6590,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5820">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Plasmodium</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1639119"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5767,6 +6600,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_58262">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Culicoidini</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_43801"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5776,6 +6610,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5833">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Plasmodium falciparum</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_418107"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5785,6 +6620,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5855">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Plasmodium vivax</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_418103"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5794,6 +6630,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_58839">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Encephalitozoon intestinalis</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6033"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5803,6 +6640,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_59140">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Myzomyia</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_44534"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5812,6 +6650,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_59142">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">funestus group</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_59140"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5821,6 +6660,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5970">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Exophiala dermatitidis</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_5583"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5830,6 +6670,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_59848">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Chrysopsini</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_43920"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5839,6 +6680,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6029">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Microsporidia</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_4751"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5848,6 +6690,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6032">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Apansporoblastina</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6029"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5857,6 +6700,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6033">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Encephalitozoon</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_36734"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5866,6 +6710,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6035">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Encephalitozoon cuniculi</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6033"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5875,6 +6720,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6072">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Eumetazoa</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_33208"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5884,6 +6730,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_61172">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Laguna Negra virus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11598"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5893,6 +6740,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6157">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Platyhelminthes</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_33213"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5902,6 +6750,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6199">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cestoda</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6157"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5911,6 +6760,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_620">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Shigella</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_543"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5920,6 +6770,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6200">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Eucestoda</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6199"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5929,6 +6780,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6201">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cyclophyllidea</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6200"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5938,6 +6790,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6202">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Taenia</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6208"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5947,6 +6800,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6204">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Taenia solium</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6202"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5956,6 +6810,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6206">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Taenia saginata</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6202"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5965,6 +6820,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6208">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Taeniidae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6201"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5974,6 +6830,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_621">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Shigella boydii</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_620"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5983,6 +6840,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_622">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Shigella dysenteriae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_620"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -5992,6 +6850,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_623">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Shigella flexneri</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_620"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6001,6 +6860,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6231">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Nematoda</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1206794"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6010,6 +6870,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_62323">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">funestus subgroup</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_59142"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6019,6 +6880,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_62324">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Anopheles funestus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_62323"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6028,6 +6890,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_624">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Shigella sonnei</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_620"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6037,6 +6900,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6249">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ascaridida</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_119089"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6046,6 +6910,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6267">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Anisakidae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_33256"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6055,6 +6920,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6268">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Anisakis</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6267"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6064,6 +6930,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6269">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Anisakis simplex</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_644710"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6073,6 +6940,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6270">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pseudoterranova</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6267"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6082,6 +6950,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6271">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pseudoterranova decipiens</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6270"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6091,6 +6960,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_629">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Yersinia &lt;bacteria&gt;</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_543"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6099,7 +6969,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_632">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Yersinia pestis</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_629"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1649845"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6108,25 +6979,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6329">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Trichocephalida</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_33218"/>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/NCBITaxon_63399 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_63399">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Arthroderma</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_34384"/>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/NCBITaxon_63402 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_63402">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Microsporum gypseum</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_34392"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1457286"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6136,6 +6990,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_63417">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Trichophyton verrucosum</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_5550"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6145,6 +7000,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_63418">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Trichophyton equinum</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_5550"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6154,6 +7010,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_63419">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Trichophyton concentricum</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_5550"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6163,6 +7020,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_63671">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Turbinidae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_216285"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6172,6 +7030,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_63672">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Turbo &lt;genus&gt;</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_63671"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6181,15 +7040,17 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_63673">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Turbo cornutus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_133423"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/NCBITaxon_639021 -->
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_640628 -->
 
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_639021">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Magnaporthales</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_222544"/>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_640628">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Poinae</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1652081"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6199,6 +7060,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6447">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mollusca</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1206795"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6208,6 +7070,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_644710">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Anisakis simplex complex</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6268"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6217,6 +7080,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6448">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gastropoda</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6447"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6226,15 +7090,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_64895">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Borrelia burgdorferi group</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_138"/>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/NCBITaxon_64899 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_64899">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dothioraceae</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_5014"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6244,6 +7100,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_65647">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ixodes holocyclus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6944"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6253,6 +7110,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_66225">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Phaeoannellomyces</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_36051"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6262,6 +7120,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6656">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Arthropoda</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_88770"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6271,6 +7130,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6657">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Crustacea</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_197562"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6280,6 +7140,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6681">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Malacostraca</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6657"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6289,6 +7150,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6682">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Eucarida</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_72041"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6298,6 +7160,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6683">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Decapoda</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6682"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6307,6 +7170,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6684">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dendrobranchiata</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6683"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6316,6 +7180,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6685">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Penaeidae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_111520"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6325,6 +7190,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6687">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Penaeus monodon</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_133894"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6334,6 +7200,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6689">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Litopenaeus vannamei</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_122377"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6343,6 +7210,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6690">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Farfantepenaeus aztecus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_85653"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6352,6 +7220,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6692">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pleocyemata</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6683"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6361,6 +7230,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6752">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Brachyura</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6692"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6370,6 +7240,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6757">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Portunidae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6774"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6379,6 +7250,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6760">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Scylla</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6757"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6388,6 +7260,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6774">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Portunoidea</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_116706"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6397,6 +7270,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6843">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Chelicerata</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6656"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6406,6 +7280,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_68525">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">delta/epsilon subdivisions</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1224"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6415,6 +7290,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6854">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Arachnida</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6843"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6424,6 +7300,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_689831">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Spinareovirinae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10880"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6433,6 +7310,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_69034">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rotaliidae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_203397"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6442,6 +7320,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6933">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Acari</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6854"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6451,6 +7330,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6934">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Parasitiformes</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6933"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6460,6 +7340,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6935">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ixodida</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6934"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6469,6 +7350,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6936">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Argasidae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_297308"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6477,7 +7359,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6937">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ornithodoros</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_352061"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6936"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6486,7 +7369,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_693762">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Schizaeales</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_3290"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1521262"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6496,6 +7380,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_693766">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Anemiaceae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_693762"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6505,6 +7390,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6939">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ixodidae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_297308"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6514,6 +7400,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_693995">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Coronavirinae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_11118"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6523,6 +7410,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_694002">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Betacoronavirus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_693995"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6532,6 +7420,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_694009">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Severe acute respiratory syndrome-related coronavirus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_694002"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6541,6 +7430,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6942">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Amblyomma</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_426441"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6550,6 +7440,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6943">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Amblyomma americanum</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6942"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6559,6 +7450,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6944">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ixodes</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_426442"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6568,6 +7460,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6945">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ixodes scapularis</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6944"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6577,6 +7470,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6946">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Acariformes</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6933"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6586,6 +7480,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6947">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Prostigmata</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_83136"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6595,6 +7490,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_69474">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Orientia</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_33988"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6604,6 +7500,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6960">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hexapoda</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_197562"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6613,6 +7510,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_69826">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ornithodoros savignyi</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6937"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6622,6 +7520,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_712">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pasteurellaceae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_135625"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6631,6 +7530,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_71239">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cucurbitales</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_91835"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6640,6 +7540,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_71240">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eudicotyledons</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1437183"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6649,6 +7550,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_71274">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">asterids</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1437201"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6658,6 +7560,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_71275">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rosids</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1437201"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6667,6 +7570,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_713">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Actinobacillus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_712"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6676,6 +7580,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7147">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Diptera</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_33392"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6685,6 +7590,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7148">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Nematocera</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_7147"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6694,6 +7600,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_715340">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pleosporineae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_92860"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6703,6 +7610,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7157">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Culicidae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_41827"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6712,6 +7620,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7158">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Aedes &lt;genus&gt;</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1056966"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6721,6 +7630,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_715962">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dothideomyceta</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_716546"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6730,6 +7640,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_715989">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sordariomyceta</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_716546"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6739,6 +7650,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7162">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ochlerotatus triseriatus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_119225"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6748,6 +7660,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7164">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Anopheles &lt;genus&gt;</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_43816"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6757,6 +7670,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7165">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Anopheles gambiae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_44542"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6766,6 +7680,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_716545">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">saccharomyceta</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_4890"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6775,6 +7690,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_716546">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">leotiomyceta</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_147538"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6784,6 +7700,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7174">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Culex &lt;genus&gt;</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_53550"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6793,6 +7710,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7178">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Culex tritaeniorhynchus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_53527"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6802,6 +7720,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7180">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Haemagogus &lt;genus&gt;</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1056966"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6811,6 +7730,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7197">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Psychodidae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_41831"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6820,6 +7740,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7198">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Phlebotominae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_7197"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6829,6 +7750,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7203">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Brachycera</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_7147"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6838,6 +7760,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_72041">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Eumalacostraca</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6681"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6847,6 +7770,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7205">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tabanidae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1262365"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6856,6 +7780,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_72171">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ziziphus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_325284"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6865,6 +7790,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_721805">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Amygdaleae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_171637"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6874,6 +7800,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_721813">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Maleae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_171637"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6883,6 +7810,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_72273">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Thiotrichales</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1236"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6892,6 +7820,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_72294">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Campylobacteraceae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_213849"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6901,6 +7830,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_723">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Actinobacillus ureae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_713"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6910,6 +7840,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_724">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Haemophilus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_712"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6917,8 +7848,9 @@
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_730 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_730">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Haemophilus ducreyi</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">[Haemophilus] ducreyi</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_724"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6927,7 +7859,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_73229">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Emmonsia</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_34383"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_299071"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6937,6 +7870,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_73230">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Emmonsia crescens</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_73229"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6946,6 +7880,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_745">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pasteurella</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_712"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6955,6 +7890,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_747">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pasteurella multocida</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_745"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6964,6 +7900,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7496">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pterygota &lt;winged insects&gt;</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_85512"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6973,6 +7910,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7509">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Siphonaptera</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_33392"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6982,6 +7920,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7511">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pulicidae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_129369"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -6991,6 +7930,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_75739">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Eucoccidiorida</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_5796"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7000,6 +7940,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_766">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rickettsiales</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_28211"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7009,6 +7950,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_768">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Anaplasma</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_942"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7018,6 +7960,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_76804">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Nidovirales</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_35278"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7027,6 +7970,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7711">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Chordata</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_33511"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7036,6 +7980,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_772">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bartonellaceae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_356"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7045,6 +7990,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_773">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bartonella</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_772"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7054,6 +8000,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_774">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bartonella bacilliformis</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_773"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7063,6 +8010,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7742">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Vertebrata &lt;Metazoa&gt;</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_89593"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7072,6 +8020,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_775">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rickettsiaceae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_766"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7081,6 +8030,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_776">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Coxiella &lt;Bacteria&gt;</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_118968"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7090,6 +8040,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_77643">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mycobacterium tuberculosis complex</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1763"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7099,6 +8050,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_777">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Coxiella burnetii</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_776"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7108,6 +8060,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7776">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gnathostomata &lt;vertebrate&gt;</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_7742"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7117,6 +8070,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_780">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rickettsia</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_33988"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7126,6 +8080,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_781">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rickettsia conorii</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_114277"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7135,6 +8090,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_782">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rickettsia prowazekii</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_114292"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7144,6 +8100,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_783">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rickettsia rickettsii</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_114277"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7153,6 +8110,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_784">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Orientia tsutsugamushi</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_69474"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7162,6 +8120,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_785">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rickettsia typhi</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_114292"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7171,6 +8130,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_78536">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Euphyllophyta</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_58023"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7180,6 +8140,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_786">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rickettsia akari</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_114277"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7189,6 +8150,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_787">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rickettsia australis</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_114277"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7198,6 +8160,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7898">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Actinopterygii</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_117571"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7207,6 +8170,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7952">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cypriniformes</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_186627"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7216,6 +8180,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7953">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cyprinidae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_30727"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7225,6 +8190,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7954">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Danio</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_7953"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7234,6 +8200,27 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7955">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Danio rerio</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_7954"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_7961 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7961">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cyprinus</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_7953"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_7962 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7962">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cyprinus carpio</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_7961"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7243,6 +8230,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_8006">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Salmoniformes</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_41705"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7252,6 +8240,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_8015">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Salmonidae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_8006"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7261,6 +8250,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_8016">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Oncorhynchus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_504568"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7270,6 +8260,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_8022">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Oncorhynchus mykiss</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_8016"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7279,6 +8270,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_8028">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Salmo</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_504568"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7288,6 +8280,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_803">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bartonella quintana</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_773"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7297,6 +8290,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_8030">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Salmo salar</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_8028"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7306,6 +8300,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_8043">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gadiformes</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1489843"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7315,6 +8310,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_8045">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gadidae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1489845"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7324,6 +8320,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_8048">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gadus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_8045"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7333,6 +8330,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_8049">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gadus morhua</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_8048"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7342,6 +8340,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_80840">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Burkholderiales</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_28216"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7351,6 +8350,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_809">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Chlamydiaceae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_51291"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7360,15 +8360,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_810">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Chlamydia</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1113537"/>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/NCBITaxon_81093 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_81093">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Magnaporthaceae</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_639021"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7378,15 +8370,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_813">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Chlamydia trachomatis</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_810"/>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/NCBITaxon_82104 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_82104">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mitosporic Herpotrichiellaceae</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_43219"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7395,7 +8379,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_82105">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cladophialophora</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_82104"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_43219"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7405,6 +8390,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_8287">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sarcopterygii</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_117571"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7414,6 +8400,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_83136">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Trombidiformes</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6946"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7423,6 +8410,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_83138">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Anystina</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6947"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7432,6 +8420,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_83141">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Parasitengona</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_83138"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7441,6 +8430,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_8457">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sauropsida</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_32524"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7450,24 +8440,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_8492">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Archosauria</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1329799"/>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/NCBITaxon_85003 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_85003">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Actinobacteridae</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1760"/>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/NCBITaxon_85005 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_85005">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Actinomycineae</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_2037"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7475,8 +8448,9 @@
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_85007 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_85007">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Corynebacterineae</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_2037"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Corynebacteriales</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1760"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7484,8 +8458,9 @@
     <!-- http://purl.obolibrary.org/obo/NCBITaxon_85009 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_85009">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Propionibacterineae</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_2037"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Propionibacteriales</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1760"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7495,6 +8470,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_85025">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Nocardiaceae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_85007"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7504,6 +8480,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_85512">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dicondylia</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_50557"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7513,6 +8490,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_85552">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Scylla paramamosain</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6760"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7522,6 +8500,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_85653">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Farfantepenaeus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_6685"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7531,6 +8510,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_85819">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Phthiraptera</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_33342"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7540,6 +8520,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_86056">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rhinocladiella mackenziei</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_5587"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7549,6 +8530,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_862507">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mus &lt;mouse, subgenus&gt;</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10088"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7558,6 +8540,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_86661">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bacillus cereus group</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1386"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7567,6 +8550,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_8782">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Aves</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_436492"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7576,6 +8560,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_8825">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Neognathae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_8782"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7585,6 +8570,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_88770">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Panarthropoda</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1206794"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7594,6 +8580,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_89593">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Craniata &lt;chordata&gt;</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_7711"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7603,6 +8590,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_8976">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Galliformes</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1549675"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7612,6 +8600,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_89940">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cladophialophora bantiana</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_82105"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7621,6 +8610,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_90010">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unclassified Enterovirus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_12059"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7630,6 +8620,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9005">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Phasianidae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_8976"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7639,6 +8630,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9030">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gallus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_9072"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7648,6 +8640,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9031">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gallus gallus</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_9030"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7657,6 +8650,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9072">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Phasianinae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_9005"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7666,6 +8660,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_90964">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Staphylococcaceae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1385"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7675,6 +8670,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_91061">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bacilli</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1239"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7684,6 +8680,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_91347">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Enterobacteriales</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_1236"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7692,7 +8689,18 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_91493">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Exserohilum</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_117568"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_28556"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_91561 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_91561">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cetartiodactyla</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_314145"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7702,6 +8710,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_91827">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gunneridae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_71240"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7711,6 +8720,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_91835">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fabids</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_71275"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7720,6 +8730,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_91836">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">malvids</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_71275"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7729,6 +8740,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_91888">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lamiids</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_71274"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7738,6 +8750,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_92088">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Trombiculoidea</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_83141"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7747,6 +8760,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_92251">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Trombiculidae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_92088"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7756,6 +8770,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_92860">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pleosporales</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_451868"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7765,6 +8780,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9347">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Eutheria</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_32525"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7774,6 +8790,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_942">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Anaplasmataceae</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_766"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7783,6 +8800,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_943">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ehrlichia</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_942"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7792,6 +8810,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_945">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ehrlichia chaffeensis</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_106178"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7801,6 +8820,7 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_948">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Anaplasma phagocytophilum</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_106179"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7810,6 +8830,77 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_951">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Neorickettsia sennetsu</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_33993"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_9845 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9845">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ruminantia</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_91561"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_9895 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9895">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bovidae</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_35500"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_9903 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9903">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bos</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_27592"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_9913 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9913">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bos taurus</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_9903"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_9922 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9922">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Capra</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_9963"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_9925 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9925">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Capra hircus</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_9922"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NCBITaxon_9963 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9963">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Caprinae</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_9895"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
     
 
@@ -7819,10 +8910,6 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9989">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rodentia</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_314147"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
     </owl:Class>
 </rdf:RDF>
-
-
-
-<!-- Generated by the OWL API (version 3.4.2) http://owlapi.sourceforge.net -->
-

--- a/src/ontology/imports/ncbitaxon_import.txt
+++ b/src/ontology/imports/ncbitaxon_import.txt
@@ -1,0 +1,315 @@
+[URI of the OWL(RDF/XML) output file]
+http://purl.obolibrary.org/obo/doid/imports/ncbitaxon_import.owl
+
+[Source ontology]
+NCBITaxon
+
+[Source term retrieval setting]
+includeAllIntermediates
+
+[Source annotation URIs]
+http://www.w3.org/2000/01/rdf-schema#label
+
+[Top level source term URIs and target direct superclass URIs]
+http://purl.obolibrary.org/obo/NCBITaxon_1      # root
+
+[Low level source term URIs]
+http://purl.obolibrary.org/obo/NCBITaxon_10090  # Mus musculus
+http://purl.obolibrary.org/obo/NCBITaxon_10116  # Rattus norvegicus
+http://purl.obolibrary.org/obo/NCBITaxon_10239  # Viruses
+http://purl.obolibrary.org/obo/NCBITaxon_10243  # Cowpox virus
+http://purl.obolibrary.org/obo/NCBITaxon_10244  # Monkeypox virus
+http://purl.obolibrary.org/obo/NCBITaxon_10245  # Vaccinia virus
+http://purl.obolibrary.org/obo/NCBITaxon_10255  # Variola virus
+http://purl.obolibrary.org/obo/NCBITaxon_10258  # Orf virus
+http://purl.obolibrary.org/obo/NCBITaxon_10279  # Molluscum contagiosum virus
+http://purl.obolibrary.org/obo/NCBITaxon_10298  # Human herpesvirus 1
+http://purl.obolibrary.org/obo/NCBITaxon_10310  # Human herpesvirus 2
+http://purl.obolibrary.org/obo/NCBITaxon_10335  # Human herpesvirus 3
+http://purl.obolibrary.org/obo/NCBITaxon_10368  # Human herpesvirus 6
+http://purl.obolibrary.org/obo/NCBITaxon_10372  # Human herpesvirus 7
+http://purl.obolibrary.org/obo/NCBITaxon_10376  # Human herpesvirus 4
+http://purl.obolibrary.org/obo/NCBITaxon_10407  # Hepatitis B virus
+http://purl.obolibrary.org/obo/NCBITaxon_10519  # Human adenovirus 7
+http://purl.obolibrary.org/obo/NCBITaxon_11020  # Barmah Forest virus
+http://purl.obolibrary.org/obo/NCBITaxon_11021  # Eastern equine encephalitis virus
+http://purl.obolibrary.org/obo/NCBITaxon_11029  # Ross River virus
+http://purl.obolibrary.org/obo/NCBITaxon_11036  # Venezuelan equine encephalitis virus
+http://purl.obolibrary.org/obo/NCBITaxon_11039  # Western equine encephalomyelitis virus
+http://purl.obolibrary.org/obo/NCBITaxon_11041  # Rubella virus
+http://purl.obolibrary.org/obo/NCBITaxon_11053  # Dengue virus 1
+http://purl.obolibrary.org/obo/NCBITaxon_11072  # Japanese encephalitis virus
+http://purl.obolibrary.org/obo/NCBITaxon_11077  # Kunjin virus
+http://purl.obolibrary.org/obo/NCBITaxon_11079  # Murray Valley encephalitis virus
+http://purl.obolibrary.org/obo/NCBITaxon_11080  # St. Louis encephalitis virus
+http://purl.obolibrary.org/obo/NCBITaxon_11082  # West Nile virus
+http://purl.obolibrary.org/obo/NCBITaxon_11083  # Powassan virus
+http://purl.obolibrary.org/obo/NCBITaxon_11084  # Tick-borne encephalitis virus
+http://purl.obolibrary.org/obo/NCBITaxon_11086  # Louping ill virus
+http://purl.obolibrary.org/obo/NCBITaxon_11089  # Yellow fever virus
+http://purl.obolibrary.org/obo/NCBITaxon_11103  # Hepatitis C virus
+http://purl.obolibrary.org/obo/NCBITaxon_11161  # Mumps virus
+http://purl.obolibrary.org/obo/NCBITaxon_11176  # Newcastle disease virus
+http://purl.obolibrary.org/obo/NCBITaxon_11234  # Measles virus
+http://purl.obolibrary.org/obo/NCBITaxon_11250  # Human respiratory syncytial virus
+http://purl.obolibrary.org/obo/NCBITaxon_11292  # Rabies virus
+http://purl.obolibrary.org/obo/NCBITaxon_11320  # Influenza A virus
+http://purl.obolibrary.org/obo/NCBITaxon_11552  # Influenza C virus
+http://purl.obolibrary.org/obo/NCBITaxon_11577  # La Crosse virus
+http://purl.obolibrary.org/obo/NCBITaxon_11588  # Rift Valley fever virus
+http://purl.obolibrary.org/obo/NCBITaxon_11593  # Crimean-Congo hemorrhagic fever virus
+http://purl.obolibrary.org/obo/NCBITaxon_11599  # Hantaan virus
+http://purl.obolibrary.org/obo/NCBITaxon_11604  # Puumala virus
+http://purl.obolibrary.org/obo/NCBITaxon_11608  # Seoul virus
+http://purl.obolibrary.org/obo/NCBITaxon_11619  # Junin virus
+http://purl.obolibrary.org/obo/NCBITaxon_11620  # Lassa virus
+http://purl.obolibrary.org/obo/NCBITaxon_11623  # Lymphocytic choriomeningitis virus
+http://purl.obolibrary.org/obo/NCBITaxon_11628  # Machupo virus
+http://purl.obolibrary.org/obo/NCBITaxon_11676  # Human immunodeficiency virus 1
+http://purl.obolibrary.org/obo/NCBITaxon_11709  # Human immunodeficiency virus 2
+http://purl.obolibrary.org/obo/NCBITaxon_118655 # Oropouche virus
+http://purl.obolibrary.org/obo/NCBITaxon_11908  # Human T-lymphotropic virus 1
+http://purl.obolibrary.org/obo/NCBITaxon_12066  # Coxsackievirus
+http://purl.obolibrary.org/obo/NCBITaxon_12080  # Human poliovirus 1
+http://purl.obolibrary.org/obo/NCBITaxon_12083  # Human poliovirus 2
+http://purl.obolibrary.org/obo/NCBITaxon_12086  # Human poliovirus 3
+http://purl.obolibrary.org/obo/NCBITaxon_12089  # Human coxsackievirus A24
+http://purl.obolibrary.org/obo/NCBITaxon_12090  # Human enterovirus 70
+http://purl.obolibrary.org/obo/NCBITaxon_12092  # Hepatitis A virus
+http://purl.obolibrary.org/obo/NCBITaxon_121224 # Pediculus humanus corporis
+http://purl.obolibrary.org/obo/NCBITaxon_121225 # Pediculus humanus
+http://purl.obolibrary.org/obo/NCBITaxon_121752 # Lacazia loboi
+http://purl.obolibrary.org/obo/NCBITaxon_121759 # Paracoccidioides brasiliensis
+http://purl.obolibrary.org/obo/NCBITaxon_12455  # Borna disease virus
+http://purl.obolibrary.org/obo/NCBITaxon_12461  # Hepatitis E virus
+http://purl.obolibrary.org/obo/NCBITaxon_12475  # Hepatitis delta virus
+http://purl.obolibrary.org/obo/NCBITaxon_12506  # Dobrava-Belgrade virus
+http://purl.obolibrary.org/obo/NCBITaxon_12542  # Omsk hemorrhagic fever virus
+http://purl.obolibrary.org/obo/NCBITaxon_12637  # Dengue virus
+http://purl.obolibrary.org/obo/NCBITaxon_127007 # Rhipicephalus pumilio
+http://purl.obolibrary.org/obo/NCBITaxon_1280   # Staphylococcus aureus
+http://purl.obolibrary.org/obo/NCBITaxon_12939  # Anemia
+http://purl.obolibrary.org/obo/NCBITaxon_129726 # Pseudocowpox virus
+http://purl.obolibrary.org/obo/NCBITaxon_1314   # Streptococcus pyogenes
+http://purl.obolibrary.org/obo/NCBITaxon_13373  # Burkholderia mallei
+http://purl.obolibrary.org/obo/NCBITaxon_134742 # Sigmodon alstoni
+http://purl.obolibrary.org/obo/NCBITaxon_137207 # Oligoryzomys longicaudatus
+http://purl.obolibrary.org/obo/NCBITaxon_138    # Borrelia
+http://purl.obolibrary.org/obo/NCBITaxon_138949 # Human enterovirus B
+http://purl.obolibrary.org/obo/NCBITaxon_139    # Borrelia burgdorferi
+http://purl.obolibrary.org/obo/NCBITaxon_1392   # Bacillus anthracis
+http://purl.obolibrary.org/obo/NCBITaxon_140564 # Ornithodoros parkeri
+http://purl.obolibrary.org/obo/NCBITaxon_1502   # Clostridium perfringens
+http://purl.obolibrary.org/obo/NCBITaxon_1513   # Clostridium tetani
+http://purl.obolibrary.org/obo/NCBITaxon_157541 # Zygodontomys brevicauda
+http://purl.obolibrary.org/obo/NCBITaxon_157914 # Ziziphus mauritiana
+http://purl.obolibrary.org/obo/NCBITaxon_15957  # Phleum pratense
+http://purl.obolibrary.org/obo/NCBITaxon_162997 # Culex annulirostris
+http://purl.obolibrary.org/obo/NCBITaxon_163159 # Xenopsylla cheopis
+http://purl.obolibrary.org/obo/NCBITaxon_1637   # Listeria
+http://purl.obolibrary.org/obo/NCBITaxon_1639   # Listeria monocytogenes
+http://purl.obolibrary.org/obo/NCBITaxon_1648   # Erysipelothrix rhusiopathiae
+http://purl.obolibrary.org/obo/NCBITaxon_1655   # Actinomyces naeslundii
+http://purl.obolibrary.org/obo/NCBITaxon_1656   # Actinomyces viscosus
+http://purl.obolibrary.org/obo/NCBITaxon_1659   # Actinomyces israelii
+http://purl.obolibrary.org/obo/NCBITaxon_1660   # Actinomyces odontolyticus
+http://purl.obolibrary.org/obo/NCBITaxon_169495 # This
+http://purl.obolibrary.org/obo/NCBITaxon_171    # Leptospira
+http://purl.obolibrary.org/obo/NCBITaxon_172148 # Alkhumra hemorrhagic fever virus
+http://purl.obolibrary.org/obo/NCBITaxon_173087 # Human papillomavirus types
+http://purl.obolibrary.org/obo/NCBITaxon_1750   # Propionibacterium propionicum
+http://purl.obolibrary.org/obo/NCBITaxon_1769   # Mycobacterium leprae
+http://purl.obolibrary.org/obo/NCBITaxon_1773   # Mycobacterium tuberculosis
+http://purl.obolibrary.org/obo/NCBITaxon_1809   # Mycobacterium ulcerans
+http://purl.obolibrary.org/obo/NCBITaxon_181088 # Haemaphysalis flava
+http://purl.obolibrary.org/obo/NCBITaxon_1824   # Nocardia asteroides
+http://purl.obolibrary.org/obo/NCBITaxon_186537 # Marburgvirus
+http://purl.obolibrary.org/obo/NCBITaxon_186538 # Zaire ebolavirus
+http://purl.obolibrary.org/obo/NCBITaxon_186540 # Sudan ebolavirus
+http://purl.obolibrary.org/obo/NCBITaxon_197    # Campylobacter jejuni
+http://purl.obolibrary.org/obo/NCBITaxon_197911 # Influenzavirus A
+http://purl.obolibrary.org/obo/NCBITaxon_197912 # Influenzavirus B
+http://purl.obolibrary.org/obo/NCBITaxon_197913 # Influenzavirus C
+http://purl.obolibrary.org/obo/NCBITaxon_2      # Bacteria <prokaryote>
+http://purl.obolibrary.org/obo/NCBITaxon_206160 # Sandfly fever Naples virus
+http://purl.obolibrary.org/obo/NCBITaxon_226665 # Rickettsia heilongjiangensis
+http://purl.obolibrary.org/obo/NCBITaxon_227859 # SARS coronavirus
+http://purl.obolibrary.org/obo/NCBITaxon_235    # Brucella abortus
+http://purl.obolibrary.org/obo/NCBITaxon_263    # Francisella tularensis
+http://purl.obolibrary.org/obo/NCBITaxon_2711   # Citrus sinensis
+http://purl.obolibrary.org/obo/NCBITaxon_27317  # Galactomyces geotrichum
+http://purl.obolibrary.org/obo/NCBITaxon_27458  # Chrysops
+http://purl.obolibrary.org/obo/NCBITaxon_27973  # Encephalitozoon hellem
+http://purl.obolibrary.org/obo/NCBITaxon_28292  # Sandfly fever Sicilian virus
+http://purl.obolibrary.org/obo/NCBITaxon_28314  # Aleutian mink disease virus
+http://purl.obolibrary.org/obo/NCBITaxon_28450  # Burkholderia pseudomallei
+http://purl.obolibrary.org/obo/NCBITaxon_29031  # Phlebotomus papatasi
+http://purl.obolibrary.org/obo/NCBITaxon_29189  # Ammonia
+http://purl.obolibrary.org/obo/NCBITaxon_29459  # Brucella melitensis
+http://purl.obolibrary.org/obo/NCBITaxon_29461  # Brucella suis
+http://purl.obolibrary.org/obo/NCBITaxon_29908  # Sporothrix schenckii
+http://purl.obolibrary.org/obo/NCBITaxon_29930  # Ixodes pacificus
+http://purl.obolibrary.org/obo/NCBITaxon_299467 # Leptotrombidium deliense
+http://purl.obolibrary.org/obo/NCBITaxon_29960  # Fenneropenaeus indicus
+http://purl.obolibrary.org/obo/NCBITaxon_30639  # Mastomys
+http://purl.obolibrary.org/obo/NCBITaxon_31704  # Human coxsackievirus A16
+http://purl.obolibrary.org/obo/NCBITaxon_329110 # Coquillettidia
+http://purl.obolibrary.org/obo/NCBITaxon_33743  # Kyasanur forest disease virus
+http://purl.obolibrary.org/obo/NCBITaxon_34105  # Streptobacillus moniliformis
+http://purl.obolibrary.org/obo/NCBITaxon_34390  # Epidermophyton
+http://purl.obolibrary.org/obo/NCBITaxon_34607  # Amblyomma cajennense
+http://purl.obolibrary.org/obo/NCBITaxon_34608  # Amblyomma hebraeum
+http://purl.obolibrary.org/obo/NCBITaxon_34609  # Amblyomma maculatum
+http://purl.obolibrary.org/obo/NCBITaxon_34610  # Amblyomma variegatum
+http://purl.obolibrary.org/obo/NCBITaxon_34613  # Ixodes ricinus
+http://purl.obolibrary.org/obo/NCBITaxon_34619  # Dermacentor
+http://purl.obolibrary.org/obo/NCBITaxon_34620  # Dermacentor andersoni
+http://purl.obolibrary.org/obo/NCBITaxon_34621  # Dermacentor variabilis
+http://purl.obolibrary.org/obo/NCBITaxon_34625  # Hyalomma
+http://purl.obolibrary.org/obo/NCBITaxon_34632  # Rhipicephalus sanguineus
+http://purl.obolibrary.org/obo/NCBITaxon_35788  # Rickettsia africae
+http://purl.obolibrary.org/obo/NCBITaxon_35789  # Rickettsia helvetica
+http://purl.obolibrary.org/obo/NCBITaxon_35790  # Rickettsia japonica
+http://purl.obolibrary.org/obo/NCBITaxon_35792  # Rickettsia parkeri
+http://purl.obolibrary.org/obo/NCBITaxon_35793  # Rickettsia sibirica
+http://purl.obolibrary.org/obo/NCBITaxon_36087  # Trichuris trichiura
+http://purl.obolibrary.org/obo/NCBITaxon_36330  # Plasmodium ovale
+http://purl.obolibrary.org/obo/NCBITaxon_3656   # Cucumis melo
+http://purl.obolibrary.org/obo/NCBITaxon_36596  # Prunus armeniaca
+http://purl.obolibrary.org/obo/NCBITaxon_36826  # Clostridium botulinum A
+http://purl.obolibrary.org/obo/NCBITaxon_36827  # Clostridium botulinum B
+http://purl.obolibrary.org/obo/NCBITaxon_36830  # Clostridium botulinum E
+http://purl.obolibrary.org/obo/NCBITaxon_36831  # Clostridium botulinum F
+http://purl.obolibrary.org/obo/NCBITaxon_36855  # Brucella canis
+http://purl.obolibrary.org/obo/NCBITaxon_37020  # Oryzomys palustris
+http://purl.obolibrary.org/obo/NCBITaxon_37162  # Mycobacterium avium complex
+http://purl.obolibrary.org/obo/NCBITaxon_37296  # Human herpesvirus 8
+http://purl.obolibrary.org/obo/NCBITaxon_3750   # Malus domestica
+http://purl.obolibrary.org/obo/NCBITaxon_3758   # Prunus domestica
+http://purl.obolibrary.org/obo/NCBITaxon_3760   # Prunus persica
+http://purl.obolibrary.org/obo/NCBITaxon_37705  # Sin Nombre virus
+http://purl.obolibrary.org/obo/NCBITaxon_37727  # Talaromyces marneffei
+http://purl.obolibrary.org/obo/NCBITaxon_37816  # Rickettsia honei
+http://purl.obolibrary.org/obo/NCBITaxon_37962  # Bayou virus
+http://purl.obolibrary.org/obo/NCBITaxon_38323  # Bartonella henselae
+http://purl.obolibrary.org/obo/NCBITaxon_39030  # Apodemus agrarius
+http://purl.obolibrary.org/obo/NCBITaxon_39054  # Human enterovirus 71
+http://purl.obolibrary.org/obo/NCBITaxon_39824  # Klebsiella granulomatis
+http://purl.obolibrary.org/obo/NCBITaxon_4081   # Solanum lycopersicum
+http://purl.obolibrary.org/obo/NCBITaxon_41283  # Chrysosporium parvum
+http://purl.obolibrary.org/obo/NCBITaxon_41820  # Culicoides <genus>
+http://purl.obolibrary.org/obo/NCBITaxon_42068  # Pneumocystis jirovecii
+http://purl.obolibrary.org/obo/NCBITaxon_42229  # Prunus avium
+http://purl.obolibrary.org/obo/NCBITaxon_42408  # Neotoma albigula
+http://purl.obolibrary.org/obo/NCBITaxon_42415  # Sigmodon hispidus
+http://purl.obolibrary.org/obo/NCBITaxon_42862  # Rickettsia felis
+http://purl.obolibrary.org/obo/NCBITaxon_446    # Legionella pneumophila
+http://purl.obolibrary.org/obo/NCBITaxon_447135 # Myodes glareolus
+http://purl.obolibrary.org/obo/NCBITaxon_45219  # Guanarito virus
+http://purl.obolibrary.org/obo/NCBITaxon_45659  # Human adenovirus 3
+http://purl.obolibrary.org/obo/NCBITaxon_45709  # Sabia virus
+http://purl.obolibrary.org/obo/NCBITaxon_46607  # Andes virus
+http://purl.obolibrary.org/obo/NCBITaxon_46839  # Colorado tick fever virus
+http://purl.obolibrary.org/obo/NCBITaxon_46919  # Whitewater Arroyo virus
+http://purl.obolibrary.org/obo/NCBITaxon_4751   # Fungi
+http://purl.obolibrary.org/obo/NCBITaxon_485    # Neisseria gonorrhoeae
+http://purl.obolibrary.org/obo/NCBITaxon_4890   # Ascomycota
+http://purl.obolibrary.org/obo/NCBITaxon_489714 # Microsporum gypseum
+http://purl.obolibrary.org/obo/NCBITaxon_49202  # Dermacentor marginatus
+http://purl.obolibrary.org/obo/NCBITaxon_499556 # Chapare virus
+http://purl.obolibrary.org/obo/NCBITaxon_519    # Bordetella parapertussis
+http://purl.obolibrary.org/obo/NCBITaxon_520    # Bordetella pertussis
+http://purl.obolibrary.org/obo/NCBITaxon_523089 # Haemaphysalis concinna
+http://purl.obolibrary.org/obo/NCBITaxon_523103 # Trichophyton mentagrophytes
+http://purl.obolibrary.org/obo/NCBITaxon_52769  # Actinomyces gerencseriae
+http://purl.obolibrary.org/obo/NCBITaxon_52773  # Actinomyces meyeri
+http://purl.obolibrary.org/obo/NCBITaxon_53551  # Sabethes
+http://purl.obolibrary.org/obo/NCBITaxon_54292  # Apodemus flavicollis
+http://purl.obolibrary.org/obo/NCBITaxon_5498   # Cladosporium
+http://purl.obolibrary.org/obo/NCBITaxon_5501   # Coccidioides immitis
+http://purl.obolibrary.org/obo/NCBITaxon_5550   # Trichophyton
+http://purl.obolibrary.org/obo/NCBITaxon_5552   # Trichosporon <Trichosporonales>
+http://purl.obolibrary.org/obo/NCBITaxon_5579   # Aureobasidium
+http://purl.obolibrary.org/obo/NCBITaxon_5597   # Pseudallescheria boydii
+http://purl.obolibrary.org/obo/NCBITaxon_5598   # Alternaria
+http://purl.obolibrary.org/obo/NCBITaxon_5600   # Phialophora
+http://purl.obolibrary.org/obo/NCBITaxon_56210  # Calomys callosus
+http://purl.obolibrary.org/obo/NCBITaxon_56211  # Calomys laucha
+http://purl.obolibrary.org/obo/NCBITaxon_56212  # Calomys musculinus
+http://purl.obolibrary.org/obo/NCBITaxon_56426  # Bartonella clarridgeiae
+http://purl.obolibrary.org/obo/NCBITaxon_5658   # Leishmania <genus>
+http://purl.obolibrary.org/obo/NCBITaxon_565995 # Bundibugyo ebolavirus
+http://purl.obolibrary.org/obo/NCBITaxon_5811   # Toxoplasma gondii
+http://purl.obolibrary.org/obo/NCBITaxon_5820   # Plasmodium
+http://purl.obolibrary.org/obo/NCBITaxon_5833   # Plasmodium falciparum
+http://purl.obolibrary.org/obo/NCBITaxon_5855   # Plasmodium vivax
+http://purl.obolibrary.org/obo/NCBITaxon_58839  # Encephalitozoon intestinalis
+http://purl.obolibrary.org/obo/NCBITaxon_5970   # Exophiala dermatitidis
+http://purl.obolibrary.org/obo/NCBITaxon_6029   # Microsporidia
+http://purl.obolibrary.org/obo/NCBITaxon_6035   # Encephalitozoon cuniculi
+http://purl.obolibrary.org/obo/NCBITaxon_61172  # Laguna Negra virus
+http://purl.obolibrary.org/obo/NCBITaxon_6204   # Taenia solium
+http://purl.obolibrary.org/obo/NCBITaxon_6206   # Taenia saginata
+http://purl.obolibrary.org/obo/NCBITaxon_621    # Shigella boydii
+http://purl.obolibrary.org/obo/NCBITaxon_622    # Shigella dysenteriae
+http://purl.obolibrary.org/obo/NCBITaxon_623    # Shigella flexneri
+http://purl.obolibrary.org/obo/NCBITaxon_62324  # Anopheles funestus
+http://purl.obolibrary.org/obo/NCBITaxon_624    # Shigella sonnei
+http://purl.obolibrary.org/obo/NCBITaxon_6269   # Anisakis simplex
+http://purl.obolibrary.org/obo/NCBITaxon_6271   # Pseudoterranova decipiens
+http://purl.obolibrary.org/obo/NCBITaxon_632    # Yersinia pestis
+http://purl.obolibrary.org/obo/NCBITaxon_63417  # Trichophyton verrucosum
+http://purl.obolibrary.org/obo/NCBITaxon_63418  # Trichophyton equinum
+http://purl.obolibrary.org/obo/NCBITaxon_63419  # Trichophyton concentricum
+http://purl.obolibrary.org/obo/NCBITaxon_63673  # Turbo cornutus
+http://purl.obolibrary.org/obo/NCBITaxon_6447   # Anisakis simplex complex
+http://purl.obolibrary.org/obo/NCBITaxon_6448   # Gastropoda
+http://purl.obolibrary.org/obo/NCBITaxon_65647  # Ixodes holocyclus
+http://purl.obolibrary.org/obo/NCBITaxon_66225  # Phaeoannellomyces
+http://purl.obolibrary.org/obo/NCBITaxon_6657   # Crustacea
+http://purl.obolibrary.org/obo/NCBITaxon_6687   # Penaeus monodon
+http://purl.obolibrary.org/obo/NCBITaxon_6689   # Litopenaeus vannamei
+http://purl.obolibrary.org/obo/NCBITaxon_6690   # Farfantepenaeus aztecus
+http://purl.obolibrary.org/obo/NCBITaxon_6943   # Amblyomma americanum
+http://purl.obolibrary.org/obo/NCBITaxon_6944   # Ixodes
+http://purl.obolibrary.org/obo/NCBITaxon_6945   # Ixodes scapularis
+http://purl.obolibrary.org/obo/NCBITaxon_69826  # Ornithodoros savignyi
+http://purl.obolibrary.org/obo/NCBITaxon_7158   # Aedes <genus>
+http://purl.obolibrary.org/obo/NCBITaxon_7162   # Ochlerotatus triseriatus
+http://purl.obolibrary.org/obo/NCBITaxon_7164   # Anopheles <genus>
+http://purl.obolibrary.org/obo/NCBITaxon_7165   # Anopheles gambiae
+http://purl.obolibrary.org/obo/NCBITaxon_7174   # Culex <genus>
+http://purl.obolibrary.org/obo/NCBITaxon_7178   # Culex tritaeniorhynchus
+http://purl.obolibrary.org/obo/NCBITaxon_7180   # Haemagogus <genus>
+http://purl.obolibrary.org/obo/NCBITaxon_723    # Actinobacillus ureae
+http://purl.obolibrary.org/obo/NCBITaxon_730    # Haemophilus ducreyi
+http://purl.obolibrary.org/obo/NCBITaxon_73230  # Emmonsia crescens
+http://purl.obolibrary.org/obo/NCBITaxon_747    # Pasteurella multocida
+http://purl.obolibrary.org/obo/NCBITaxon_774    # Bartonella bacilliformis
+http://purl.obolibrary.org/obo/NCBITaxon_777    # Coxiella burnetii
+http://purl.obolibrary.org/obo/NCBITaxon_780    # Rickettsia
+http://purl.obolibrary.org/obo/NCBITaxon_781    # Rickettsia conorii
+http://purl.obolibrary.org/obo/NCBITaxon_782    # Rickettsia prowazekii
+http://purl.obolibrary.org/obo/NCBITaxon_783    # Rickettsia rickettsii
+http://purl.obolibrary.org/obo/NCBITaxon_784    # Orientia tsutsugamushi
+http://purl.obolibrary.org/obo/NCBITaxon_785    # Rickettsia typhi
+http://purl.obolibrary.org/obo/NCBITaxon_786    # Rickettsia akari
+http://purl.obolibrary.org/obo/NCBITaxon_787    # Rickettsia australis
+http://purl.obolibrary.org/obo/NCBITaxon_7898   # Actinopterygii
+http://purl.obolibrary.org/obo/NCBITaxon_7955   # Danio rerio
+http://purl.obolibrary.org/obo/NCBITaxon_7962   # Cyprinus carpio
+http://purl.obolibrary.org/obo/NCBITaxon_8022   # Oncorhynchus mykiss
+http://purl.obolibrary.org/obo/NCBITaxon_803    # Bartonella quintana
+http://purl.obolibrary.org/obo/NCBITaxon_8030   # Salmo salar
+http://purl.obolibrary.org/obo/NCBITaxon_8049   # Gadus morhua
+http://purl.obolibrary.org/obo/NCBITaxon_813    # Chlamydia trachomatis
+http://purl.obolibrary.org/obo/NCBITaxon_85552  # Scylla paramamosain
+http://purl.obolibrary.org/obo/NCBITaxon_86056  # Rhinocladiella mackenziei
+http://purl.obolibrary.org/obo/NCBITaxon_89940  # Cladophialophora bantiana
+http://purl.obolibrary.org/obo/NCBITaxon_9031   # Gallus gallus
+http://purl.obolibrary.org/obo/NCBITaxon_91493  # Exserohilum
+http://purl.obolibrary.org/obo/NCBITaxon_945    # Ehrlichia chaffeensis
+http://purl.obolibrary.org/obo/NCBITaxon_948    # Anaplasma phagocytophilum
+http://purl.obolibrary.org/obo/NCBITaxon_951    # Neorickettsia sennetsu
+http://purl.obolibrary.org/obo/NCBITaxon_9913   # Bos taurus
+http://purl.obolibrary.org/obo/NCBITaxon_9925   # Capra hircus


### PR DESCRIPTION
- same as PR #211, but based on latest master branch
- add `ncbitaxon_imports.txt` with all taxa used in `doid-edit.owl` and `ext.owl`,
    and required for IEDB requests DOID:0060492 through DOID:0060532
- update `Makefile` to fetch from OntoFox automatically
- `ncbitaxon_imports.owl`:
    - now includes IAO_0000412 'imported from' axioms (OntoFox default)
    - some new labels, new and removed ancestors, due to Taxonomy changes