### PR TITLE
uberon_import.owl fixed parser errors

### DIFF
--- a/src/ontology/imports/uberon_import.owl
+++ b/src/ontology/imports/uberon_import.owl
@@ -7,7 +7,9 @@
      xmlns:xml="http://www.w3.org/XML/1998/namespace"
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-     xmlns:obo="http://purl.obolibrary.org/obo/">
+     xmlns:obo="http://purl.obolibrary.org/obo/"
+     xmlns:foaf="http://xmlns.com/foaf/0.1/"
+     xmlns:dc="http://purl.org/dc/elements/1.1/">
     <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/doid/imports/uberon_import.owl"/>
     
 
@@ -1441,14 +1443,6 @@
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FMA:222905</oboInOwl:hasDbXref>
     </owl:Axiom>
 
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0013765"/>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A subdivision of the digestive tract that connects the small intestine to the cloaca or anus. Lacks or has few villi[Kardong].</obo:IAO_0000115>
-        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000059</oboInOwl:id>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">large intestine</rdfs:label>
-    </owl:Class>
-
-    
-
 
     <!-- http://purl.obolibrary.org/obo/UBERON_0000171 -->
 
@@ -1965,8 +1959,6 @@
         <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000079</oboInOwl:id>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male reproductive system</rdfs:label>
     </owl:Class>
-a
-    
 
 
     <!-- http://purl.obolibrary.org/obo/UBERON_0000465 -->
@@ -6659,6 +6651,7 @@ a
         <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0001560</oboInOwl:id>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/uberon/core#non_informative"/>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">neck of organ</rdfs:label>
+    </owl:Class>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0002349">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0005983"/>
@@ -6667,9 +6660,7 @@ a
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">the middle layer of the heart, comprised mainly of striated cardiac muscle fibers</obo:IAO_0000115>
         <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0002349</oboInOwl:id>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">myocardium</rdfs:label>
-
     </owl:Class>
-    
 
 
 
@@ -8641,10 +8632,6 @@ a
         <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/uberon/core#PLURAL"/>
     </owl:Axiom>
 
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">skin gland</rdfs:label>
-    </owl:Class>
-    
-
 
     <!-- http://purl.obolibrary.org/obo/UBERON_0002420 -->
 
@@ -8966,7 +8953,6 @@ a
     
 
 
-a
     <!-- http://purl.obolibrary.org/obo/UBERON_0003102 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0003102">
@@ -9929,9 +9915,7 @@ a
         <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">venae cavae</owl:annotatedTarget>
         <oboInOwl:hasDbXref rdf:resource="http://en.wikipedia.org/wiki/Venae_cavae"/>
         <oboInOwl:hasSynonymType rdf:resource="http://purl.obolibrary.org/obo/uberon/core#PLURAL"/>
-
-    </owl:Class>
-    
+    </owl:Axiom>
 
 
     <!-- http://purl.obolibrary.org/obo/UBERON_0004108 -->


### PR DESCRIPTION
It looks like the process that was used to produce uberon_import.owl does not include running it through an xml parser. I have cleaned up the obvious parse errors which prevent everyone from loading doid.owl, but there may be other more subtle issues.