### PR TITLE
Fix invalid xref in DOID:0070029

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ DO OBO and OWL files are available in our GitHub repository. The DO provides bot
 DO website: http://www.disease-ontology.org
 
 DO production has moved to OWL (November 2015).
-DO will maintain our SVN repository, mirroring updates from GitHub on a weekly basis. 
+DO will maintain our SVN repository, mirroring updates from GitHub on a weekly basis.
 
-A tutorial describing DO's editorial activies is avaiable at: 
+A tutorial describing DO's editorial activies is available at:
 https://github.com/DiseaseOntology/HumanDiseaseOntology/blob/master/src/ontology/README-editors.md
 
 Documentation on [Disease Ontology web site](http://disease-ontology.org).


### PR DESCRIPTION
Hi!  
This is small syntax fix for `DOID:0070029` where several xref URLs were not properly separated.