### PR TITLE
[DO NOT MERGE] Change definition xrefs to definition source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,6 +191,13 @@ $(DNC).obo: $(EDIT_OBO) | $(ROBOT_JAR)
 	cp $@ $(HD).obo && \
 	rm $(basename $@)-temp.obo && echo "Created $@"
 
+# DNC_OBO is used for generating the subsets later
+# Otherwise there's an issue with the base prefix
+DNC_OBO = $(BUILD)doid-non-classified-obo.owl
+$(DNC_OBO): $(DNC).obo
+	@$(ROBOT) convert --input $< --output $@ \
+	&& sed -i '' 's|$(OBO)doid/doid-non-classified\.obo#|$(OBO)doid#|g' $@ \
+	&& echo "Created temp OBO build file: $@"
 
 $(DNC).json: $(DNC).owl | $(ROBOT_JAR)
 	@$(ROBOT) convert --input $< --output $@ \
@@ -219,7 +226,7 @@ $(OWL_SUBS): $(DNC).owl | $(ROBOT_JAR)
 	 --ontology-iri "$(OBO)doid/subsets/$(notdir $@)" --output $@ && \
 	echo "Created $@"
 
-$(OBO_SUBS): $(DNC).obo | $(ROBOT_JAR)
+$(OBO_SUBS): $(DNC_OBO) | $(ROBOT_JAR)
 	@$(ROBOT) filter --input $< \
 	 --select "oboInOwl:inSubset=<$(OBO)doid#$(basename $(notdir $@))> annotations" \
 	annotate --version-iri "$(OBO)doid/$(DATE)/subsets/$(notdir $@)"\

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,8 @@ $(BUILD)dbxrefs.ttl: $(EDIT) | $(ROBOT_JAR)
 $(EDIT_OBO): $(EDIT) $(BUILD)dbxrefs.ttl | $(ROBOT_JAR)
 	@$(ROBOT) --add-prefix "obo: http://purl.obolibrary.org/obo/"\
 	 --add-prefix "oboInOwl: http://www.geneontology.org/formats/oboInOwl#" \
-	remove --input $< --term IAO:0000119 --output $(basename $@)-temp.ttl && \
+	remove --input $< --term IAO:0000119 --term OBI:9991118\
+	 --output $(basename $@)-temp.ttl && \
 	cat $(basename $@)-temp.ttl $(word 2,$^) > $(basename $@).ttl && \
 	$(ROBOT) repair --input $(basename $@).ttl --merge-axiom-annotations true \
 	convert --format ofn --output $@ && \

--- a/src/sparql/add-dbxrefs.rq
+++ b/src/sparql/add-dbxrefs.rq
@@ -1,0 +1,13 @@
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+CONSTRUCT { _:b0 a owl:Axiom ;
+                 owl:annotatedSource ?s ;
+		         owl:annotatedProperty obo:IAO_0000115 ;
+		         owl:annotatedTarget ?definition ;
+		         oboInOwl:hasDbXref ?dbXref . }
+WHERE { ?s obo:IAO_0000115 ?definition ;
+		   obo:IAO_0000119 ?dbXref . }


### PR DESCRIPTION
This PR changes oboInOwl:hasDbXref annotations on definition axioms to 'definiton source' annotations. This will allow us to easily annotate 'definiton source' with an ECO code, as discussed in #673.

These ECO codes have not been added to the 'definition source' annotations yet, this is just a WIP to demonstrate how this can work.

'definition source' is not an OBO annotation property and many users rely on the OBO-format oboInOwl:hasDbXref. This PR also updates the Makefile so that all OBO release products still used oboInOwl:hasDbXref for definition sources, and those files will not appear any different.