### PR TITLE
Fix update_robot in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ update_robot:
 	rm -rf build/robot.jar && make build/robot.jar
 
 build/robot.jar: | build
-	curl -L -o $@ https://github.com/ontodev/robot/releases/download/v1.7.2/robot.jar
+	curl -L -o $@ https://github.com/ontodev/robot/releases/latest/download/robot.jar
 
 ROBOT := java -jar build/robot.jar
 


### PR DESCRIPTION
**PROBLEM:** make update_robot does not update build/robot.jar to
latest release as intended and instead is set to download v1.7.2.

<img width="758" alt="Screen Shot 2021-08-16 at 2 38 58 PM" src="https://user-images.githubusercontent.com/21225409/129617077-e58ab88e-6051-4b89-90fa-a23ee3695c9f.png">

**FIX:** Change URL to link to latest release (currently 1.8.1) as described by Github

_See also_ https://docs.github.com/en/github/administering-a-repository/releasing-projects-on-github/linking-to-releases