### PR TITLE
Create SPARQL query to test for invalid IDs

### DIFF
--- a/src/sparql/extra/class_id_invalid.rq
+++ b/src/sparql/extra/class_id_invalid.rq
@@ -1,0 +1,16 @@
+# identifies IDs that were mistyped and do not match the class
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+
+SELECT ?class ?id
+WHERE {
+    # identify active classes & id
+	?class a owl:Class ;
+		oboInOwl:id ?id .
+	FILTER NOT EXISTS { ?class owl:deprecated ?any . }
+
+	# capture & compare class/id numbers
+	BIND(STRAFTER(str(?id), ":") AS ?id_num)
+	BIND(STRAFTER(str(?class), "_") AS ?class_num)
+	FILTER (str(?class_num) != str(?id_num))
+}


### PR DESCRIPTION
**PROBLEM:**
oboInOwl:id are manually entered in Protege and can be different
than the assigned class number, potentially lead to errors.

_Actual Example:_
In v2021-07-29 release Klippel-Feil Syndrome 3 (class DOID_0080591)
has an non-matching ID DOID:0080592.

**FIX:**
This SPARQL query identifies classes with oboInOwl:id not matching
the expected class and could be instituted as a release test.

_Details:_
This query is designed to work for all purl obo classes. It is
not limited to testing DOIDs only but should also identify such
errors in ontology imports. It  could be broadened further to any
entity that has an oboInOwl:id attribute, if desired.