### PR TITLE
Retain definitions and xrefs from imports

### DIFF
--- a/src/ontology/imports/annotations.txt
+++ b/src/ontology/imports/annotations.txt
@@ -1,4 +1,5 @@
 rdfs:label
 oboInOwl:id
 obo:IAO_0000115
+oboInOwl:hasDbXref
 owl:deprecated


### PR DESCRIPTION
This PR is an optional enhancement that will retain all oboInOwl:hasDbXref triples in all imports, thereby also **retaining definitions**.

### Analysis of (minor) problem :
Definitions from imports with definition sources are stripped (e.g. SYMP, UBERON, CL, . This is because oboInOwl:hasDbXref's are removed and the definition source axioms depend on them.

There's no way to drop only oboInOwl:hasDbXref triples within definition axioms with ROBOT.

_In order to retain definitions (when they have sources) all oboInOwl:hasDbXref statements must be retained._
