### PR TITLE
Fix dependencies for update-releases action

### DIFF
--- a/.github/workflows/update-releases.yml
+++ b/.github/workflows/update-releases.yml
@@ -8,10 +8,10 @@ jobs:
     name: Update Releases
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
-          python-version: '3.6'
+          python-version: '3.10'
       - name: Login to GH
         env:
           TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Fails with python version error "Error: Version 3.6 with arch x64 not found" likely because ubuntu-latest has changed to Ubuntu 22.04 and python 3.6 is not available (actions/runner-images#6399).

See also actions/setup-python#162.

Modifications were **_successful_** after manual execution.