### PR TITLE
Create infectious disease subset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,6 +165,28 @@ add_british_synonyms: $(EDIT) build/british_synonyms.owl | build/robot.jar
 	&& mv doid-edit.ofn $(EDIT)
 	@echo "British synonyms added to $(EDIT)!"
 
+
+# ----------------------------------------
+# AUTO-ADD TO INFECTIOUS DISEASE SUBSET
+# ----------------------------------------
+
+infectious_disease_slim: $(EDIT) src/sparql/build/infectious_disease_not_slim.rq | build/robot.jar
+	@$(ROBOT) reason \
+	 --input $< \
+	query \
+	 --query $(word 2,$^) build/infectious_disease_not_slim.tsv
+	@sed '1s/.*/ID\tsubset\nID\tAI oboInOwl:inSubset/' build/infectious_disease_not_slim.tsv | \
+	 sed 's/<//' | \
+	 sed 's|>|\thttp://purl.obolibrary.org/obo/doid#DO_infectious_disease_slim|' > build/infectious_disease_template.tsv
+	@$(ROBOT) template \
+	 --merge-before \
+	 --input $< \
+	 --template build/infectious_disease_template.tsv \
+	convert \
+	 --format ofn \
+	 --output $<
+
+
 # ----------------------------------------
 # RELEASE
 # ----------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -347,7 +347,7 @@ $(DNC).json: $(DNC).owl | build/robot.jar
 SUB_NAMES = DO_AGR_slim DO_cancer_slim DO_FlyBase_slim DO_GXD_slim DO_IEDB_slim DO_MGI_slim\
  DO_rare_slim DO_RAD_slim DO_CFDE_slim GOLD NCIthesaurus TopNodes_DOcancerslim gram-negative_bacterial_infectious_disease\
  gram-positive_bacterial_infectious_disease sexually_transmitted_infectious_disease\
- tick-borne_infectious_disease zoonotic_infectious_disease
+ tick-borne_infectious_disease zoonotic_infectious_disease DO_infectious_disease_slim
 SUBS = $(foreach N,$(SUB_NAMES),$(addprefix src/ontology/subsets/, $(N)))
 OWL_SUBS = $(foreach N,$(SUBS),$(addsuffix .owl, $(N)))
 OBO_SUBS = $(foreach N,$(SUBS),$(addsuffix .obo, $(N)))

--- a/src/sparql/build/infectious_disease_not_slim.rq
+++ b/src/sparql/build/infectious_disease_not_slim.rq
@@ -1,0 +1,17 @@
+# identify all infectious disease branch terms that are not in
+#	DO_infectious_disease_slim
+
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+PREFIX doid: <http://purl.obolibrary.org/obo/doid#>
+
+SELECT ?class
+WHERE {
+    ?class a owl:Class ;
+        rdfs:subClassOf* obo:DOID_0050117 .
+
+    FILTER NOT EXISTS { ?class oboInOwl:inSubset doid:DO_infectious_disease_slim . }
+    FILTER NOT EXISTS { ?class owl:deprecated ?any . }
+}


### PR DESCRIPTION
Creates the new infectious disease subset `DO_infectious_disease_slim` including all current _asserted children_ of the 'disease by infectious agent' branch.

@lschriml I'm not sure this is the right way to create this subset. If it really should include all the infectious diseases in the 'disease by infectious agent' branch, I think these annotations need to be added post-reasoning. 'osteomyelitis' (DOID:1019) for example, is not annotated as part of this subset.

Also, it's not clear to me if preserving the entire structure of the branch is desirable or not. This may depend on how the subset is to be used. In this PR, **all** of the terminal **and** intermediate classes of the 'disease by infectious agent' branch are added in the subset (all the way up to the branch top-level term itself).

We could probably set up a SPARQL query + ROBOT template system to update the members of this slim in the doid.owl file post-reasoning. With this approach, membership would not be reflected in the doid-edit.owl file. We might also need to set up some sort of check.