### PR TITLE
Tests to verify scoped logical axioms

### DIFF
--- a/src/sparql/verify/edit-verify-disease_has_feature.rq
+++ b/src/sparql/verify/edit-verify-disease_has_feature.rq
@@ -4,7 +4,7 @@ PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX obo: <http://purl.obolibrary.org/obo/>
 PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
 
-SELECT ?not_disease
+SELECT ?class ?type ?not_disease
 WHERE {
     ?anonymous a owl:Restriction ;
         owl:onProperty obo:RO_0004029 ;
@@ -12,4 +12,10 @@ WHERE {
 
     FILTER(isBlank(?anonymous))
     FILTER(!isBlank(?not_disease) && !CONTAINS(str(?not_disease), "DOID"))
+
+    OPTIONAL {
+        VALUES ?type { rdfs:subClassOf owl:equivalentClass }
+        ?class a owl:Class ;
+            ?type ?anonymous .
+    }
 }

--- a/src/sparql/verify/edit-verify-disease_has_feature.rq
+++ b/src/sparql/verify/edit-verify-disease_has_feature.rq
@@ -1,0 +1,14 @@
+# verify all 'has symptom' axioms use SYMP
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+
+SELECT ?not_disease
+WHERE {
+    ?anonymous a owl:Restriction ;
+        owl:onProperty obo:RO_0004029 ;
+        owl:someValuesFrom ?not_disease .
+
+    FILTER(isBlank(?anonymous))
+    FILTER(!isBlank(?not_disease) && !CONTAINS(str(?not_disease), "DOID"))
+}

--- a/src/sparql/verify/edit-verify-disease_has_feature.rq
+++ b/src/sparql/verify/edit-verify-disease_has_feature.rq
@@ -1,6 +1,7 @@
-# verify all 'has symptom' axioms use SYMP
+# verify all 'disease has feature' axioms use DOID
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
 PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
 
 SELECT ?not_disease

--- a/src/sparql/verify/edit-verify-has_phenotype.rq
+++ b/src/sparql/verify/edit-verify-has_phenotype.rq
@@ -1,6 +1,7 @@
-# verify all 'has symptom' axioms use SYMP
+# verify all 'has phenotype' axioms use HP
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
 PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
 
 SELECT ?not_phenotype

--- a/src/sparql/verify/edit-verify-has_phenotype.rq
+++ b/src/sparql/verify/edit-verify-has_phenotype.rq
@@ -4,7 +4,7 @@ PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX obo: <http://purl.obolibrary.org/obo/>
 PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
 
-SELECT ?not_phenotype
+SELECT ?class ?type ?not_phenotype
 WHERE {
     ?anonymous a owl:Restriction ;
         owl:onProperty obo:RO_0002200 ;
@@ -12,4 +12,10 @@ WHERE {
 
     FILTER(isBlank(?anonymous))
     FILTER(!isBlank(?not_phenotype) && !CONTAINS(str(?not_phenotype), "HP_"))
+
+    OPTIONAL {
+        VALUES ?type { rdfs:subClassOf owl:equivalentClass }
+        ?class a owl:Class ;
+            ?type ?anonymous .
+    }
 }

--- a/src/sparql/verify/edit-verify-has_phenotype.rq
+++ b/src/sparql/verify/edit-verify-has_phenotype.rq
@@ -1,0 +1,14 @@
+# verify all 'has symptom' axioms use SYMP
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+
+SELECT ?not_phenotype
+WHERE {
+    ?anonymous a owl:Restriction ;
+        owl:onProperty obo:RO_0002200 ;
+        owl:someValuesFrom ?not_phenotype .
+
+    FILTER(isBlank(?anonymous))
+    FILTER(!isBlank(?not_phenotype) && !CONTAINS(str(?not_phenotype), "HP_"))
+}

--- a/src/sparql/verify/edit-verify-has_symptom.rq
+++ b/src/sparql/verify/edit-verify-has_symptom.rq
@@ -4,7 +4,7 @@ PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX obo: <http://purl.obolibrary.org/obo/>
 PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
 
-SELECT ?not_symptom
+SELECT ?class ?type ?not_symptom
 WHERE {
     ?anonymous a owl:Restriction ;
         owl:onProperty obo:RO_0002452 ;
@@ -12,4 +12,10 @@ WHERE {
 
     FILTER(isBlank(?anonymous))
     FILTER(!isBlank(?not_symptom) && !CONTAINS(str(?not_symptom), "SYMP"))
+
+    OPTIONAL {
+        VALUES ?type { rdfs:subClassOf owl:equivalentClass }
+        ?class a owl:Class ;
+            ?type ?anonymous .
+    }
 }

--- a/src/sparql/verify/edit-verify-has_symptom.rq
+++ b/src/sparql/verify/edit-verify-has_symptom.rq
@@ -1,0 +1,14 @@
+# verify all 'has symptom' axioms use SYMP
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+
+SELECT ?not_symptom
+WHERE {
+    ?anonymous a owl:Restriction ;
+        owl:onProperty obo:RO_0002452 ;
+        owl:someValuesFrom ?not_symptom .
+
+    FILTER(isBlank(?anonymous))
+    FILTER(!isBlank(?not_symptom) && !CONTAINS(str(?not_symptom), "SYMP"))
+}

--- a/src/sparql/verify/edit-verify-has_symptom.rq
+++ b/src/sparql/verify/edit-verify-has_symptom.rq
@@ -1,6 +1,7 @@
 # verify all 'has symptom' axioms use SYMP
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
 PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
 
 SELECT ?not_symptom


### PR DESCRIPTION
This adds tests to identify classes from outside the the appropriate scope for `has symptom` (SYMP), `has phenotype` (HP) and `disease has feature` (DOID) based logical axioms.

There are currently two design limitations because these are SPARQL-based tests:

1. They only work for axiom phrases where the object property is immediately followed by the class. It will _not_ work where the restriction is on a union or intersection of classes (e.g. `'has symptom' some (ptosis or fever or conjunctivitis)`).
2. The report of errors only returns the mis-scoped class that follows the object property. It does not tell you which DO disease has the axiom.