### PR TITLE
Change auto-update of rare slim to include children of rare diseases

### DIFF
--- a/src/sparql/update/DO_rare_slim.rq
+++ b/src/sparql/update/DO_rare_slim.rq
@@ -10,7 +10,9 @@ PREFIX doid: <http://purl.obolibrary.org/obo/doid#>
 SELECT ?class
 WHERE {
     ?class a owl:Class ;
-        oboInOwl:hasDbXref ?xref .
+        rdfs:subClassOf* ?rare_class .
+    ?rare_class oboInOwl:hasDbXref ?xref .
+
     FILTER(REGEX(str(?xref), "GARD|ORDO"))
     FILTER NOT EXISTS { ?class oboInOwl:inSubset doid:DO_rare_slim . }
     FILTER NOT EXISTS { ?class owl:deprecated ?any . }


### PR DESCRIPTION
This updates the make rule that automatically adds diseases to the DO_rare_slim. The original version (still currently active) adds diseases with ORDO or GARD xrefs only. This change would also add any disease that is a child of those diseases.

While this seems theoretically correct, there are a surprising number of diseases added and it seems likely they are not all rare (particularly for cancers).

Instead of implementing this as is, it might be wise to first accomplish one or more of the following and then revise the theory of what is considered rare:
- Formulate a model for identifying rare diseases based on global and regional criteria.
- Review the diseases currently in the rare disease subset and remove those that are no longer considered rare by Orphanet and GARD.
- Create an exclude list to avoid re-adding curated diseases that are not rare. This might be particularly relevant if we choose to keep Orphanet and/or GARD xrefs on diseases even after they deprecate them due to non-rarity in their region.