### PR TITLE
Fix Github action that updates RELEASE.md

### DIFF
--- a/.github/workflows/update-releases.yml
+++ b/.github/workflows/update-releases.yml
@@ -14,7 +14,7 @@ jobs:
           python-version: '3.10'
       - name: Login to GH
         env:
-          TOKEN: ${{ secrets.GH_TOKEN }}
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: echo "$TOKEN" > .token.txt && gh auth login --with-token < .token.txt && rm .token.txt
       - name: Update Releases
         run: python3 src/util/update-releases.py RELEASES.md
@@ -23,4 +23,4 @@ jobs:
         with:
           file-path: RELEASES.md
           commit-msg: Update RELEASES.md
-          github-token: ${{ secrets.GH_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Corrects the name for using the Github token to commit automatically. Already ran manually and confirmed that it fixed the issue with previous runs and completed without error.