### PR TITLE
Improve versioning & fix diff warning when building release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -491,8 +491,10 @@ $(REFRESH_IMPS):
 # AUTOMATED IMPORTS -- MERGE ONLY
 # ----------------------------------------
 
+# version omim_susc_import.owl first to avoid file churn with repeat commands
 build/update/omim-susc-invert.owl: $(EDIT) src/ontology/imports/omim_susc_import.owl \
- src/sparql/update/omim-susc-invert.rq | check_robot build/update
+ src/sparql/update/omim-susc-invert.rq | check_robot build/update \
+ version_omim_susc
 	@echo "Inverting OMIM susceptibility relations..."
 	@$(ROBOT) merge \
 	 --input $< \
@@ -791,18 +793,21 @@ VERSION_IMPS = $(foreach I,$(IMPS) $(MANUAL_IMPS),$(addprefix version_, $(I)))
 version_imports: $(VERSION_IMPS) version_ext
 
 version_ext: src/ontology/ext.owl | check_robot
-	@$(ROBOT) annotate \
-	 --input $< \
-	 --version-iri "$(RELEASE_PREFIX)ext.owl" \
-	 --output $<
-	@echo "Updated versionIRI of $<"
+	@CUR_VERS=$$(cat $< | $(extract_versionIRI)) ; \
+	NEW_VERS="$(RELEASE_PREFIX)ext.owl" ; \
+	if [[ "$$CUR_VERS" != "$$NEW_VERS" ]]; then \
+		$(ROBOT) annotate --input $< --version-iri "$$NEW_VERS" --output $< ; \
+		echo "Updated versionIRI of $<" ; \
+	fi
 
+# only version if needed to avoid omim_susc_import.owl forced file churn
 $(VERSION_IMPS): version_%: src/ontology/imports/%_import.owl | check_robot
-	@$(ROBOT) annotate \
-	 --input $< \
-	 --version-iri "$(RELEASE_PREFIX)imports/$(notdir $<)" \
-	 --output $<
-	@echo "Updated versionIRI of $<"
+	@CUR_VERS=$$(cat $< | $(extract_versionIRI)) ; \
+	NEW_VERS="$(RELEASE_PREFIX)imports/$(notdir $<)" ; \
+	if [[ "$$CUR_VERS" != "$$NEW_VERS" ]]; then \
+		$(ROBOT) annotate --input $< --version-iri "$$NEW_VERS" --output $< ; \
+		echo "Updated versionIRI of $<" ; \
+	fi
 
 
 # ----------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ SHELL := bash
 .SECONDARY:
 .NOTPARALLEL:
 
+include src/util/functions.mk
+
 DO = src/ontology/doid
 EDIT = src/ontology/doid-edit.owl
 OBO = http://purl.obolibrary.org/obo/

--- a/Makefile
+++ b/Makefile
@@ -463,20 +463,20 @@ MANUAL_IMPS := omim_susc
 
 imports: | check_robot
 	@echo "Checking import modules..."
-	@cd src/ontology/imports && $(MAKE) imports
+	@$(MAKE) -C src/ontology/imports imports
 
 refresh_imports: | check_robot
 	@echo "Refreshing import modules (this may take some time)..."
-	@cd src/ontology/imports && $(MAKE) refresh_imports
+	@$(MAKE) -C src/ontology/imports refresh_imports
 
 $(IMPS): | check_robot
 	@echo "Generating $@ import module..."
-	@cd src/ontology/imports && $(MAKE) $@
+	@$(MAKE) -C src/ontology/imports $@
 
 # Refresh (clean & rebuild) *individual* imports with `refresh_{import}`
 REFRESH_IMPS := $(foreach IMP,$(IMPS),refresh_$(IMP))
 $(REFRESH_IMPS):
-	@cd src/ontology/imports && $(MAKE) $@
+	@$(MAKE) -C src/ontology/imports $@
 
 .PHONY: imports refresh_imports $(IMPS) $(REFRESH_IMPS)
 

--- a/src/ontology/imports/Makefile
+++ b/src/ontology/imports/Makefile
@@ -6,6 +6,10 @@ SHELL := bash
 .DELETE_ON_ERROR:
 .SUFFIXES:
 
+# Get functions from src/util/functions.mk
+SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+include $(SELF_DIR)/../../util/functions.mk
+
 OBO = http://purl.obolibrary.org/obo/
 ROBOT := java -Xmx10G -jar ../../../build/robot.jar
 
@@ -89,19 +93,6 @@ define announce_version
 		SRC_VERS=$${SRC_VERS#"$$NS"} ; \
 		echo "Updating $(1): $${CUR_VERS} >> $${SRC_VERS}" ; \
 	fi ;
-endef
-
-# Extracts versionIRI from pre-opened OWL files (works for local & remote files)
-# NOTES:
-# 1. Reads stdin ONLY to versionIRI -> req'd to avoid long read time of
-#	large files (e.g. chebi).
-# 2. The last `sed` replaces a custom XML entity (used in foodon) with the OBO
-#	URI it represents (i.e. '&obo;' -> 'http://purl.obolibrary.org/obo/'),
-#	see https://www.w3schools.com/xml/xml_dtd_entities.asp for bkgd info.
-define extract_versionIRI
-	sed -n '/owl:versionIRI/p;/owl:versionIRI/q' | \
-	sed -E 's/.*"([^"]+)".*/\1/' | \
-	sed 's|&obo;|http://purl.obolibrary.org/obo/|'
 endef
 
 # Save *_import.owl before update for comparison

--- a/src/util/functions.mk
+++ b/src/util/functions.mk
@@ -1,0 +1,12 @@
+# Extracts versionIRI from pre-opened OWL files (works for local & remote files)
+# NOTES:
+# 1. Reads stdin ONLY to versionIRI -> req'd to avoid long read time of
+#	large files (e.g. chebi).
+# 2. The last `sed` replaces a custom XML entity (used in foodon) with the OBO
+#	URI it represents (i.e. '&obo;' -> 'http://purl.obolibrary.org/obo/'),
+#	see https://www.w3schools.com/xml/xml_dtd_entities.asp for bkgd info.
+define extract_versionIRI
+	sed -n '/owl:versionIRI/p;/owl:versionIRI/q' | \
+	sed -E 's/.*"([^"]+)".*/\1/' | \
+	sed 's|&obo;|http://purl.obolibrary.org/obo/|'
+endef

--- a/src/util/report-diff.py
+++ b/src/util/report-diff.py
@@ -31,7 +31,7 @@ def get_reports():
 	reports = []
 	for f in files:
 		if '-report.rq' in f:
-			reports.append(re.sub('\.rq$', '', f))
+			reports.append(re.sub(r'\.rq$', '', f))
 	return reports
 
 if __name__ == '__main__':
@@ -51,7 +51,7 @@ if __name__ == '__main__':
 			sign = '+'
 			if v < 0:
 				sign = '-'
-			out = '\t' + re.sub('^\?', '', h.strip()) + t + sign + str(v)
+			out = '\t' + re.sub(r'^\?', '', h.strip()) + t + sign + str(v)
 			output.append(out)
 	with open('build/reports/report-diff.txt', 'w+') as f:
 		for o in output:


### PR DESCRIPTION
## Problems
1. When interrupted or a single file needs to be updated re-running `make release` or another downstream command, causes all of the imports to be re-versioned. Previously, this wasn't a problem but now that `omim_susc_import.owl` is used to dynamically generate inverted susceptiblity axioms, on which doid.owl creation depends, the whole release pipeline gets re-run.
2. An warning occurs each time the older python diff is run (this may be obsolete now), due to mistakes in python regex practices.

## Fixes
1. Import versionIRIs are now only changed when they are not up-to-date.
    - To support this change, `extract_versionIRI` has been moved to the new `src/util/functions.mk`, so it can be accessed by all Makefiles.
2. Python regex's have been standardized.

A few minor additional updates were made in the primary Makefile to use more standard make.